### PR TITLE
[IMP] Ticket #537 Team onchange event for scope

### DIFF
--- a/helpdesk_scope/models/helpdesk_ticket.py
+++ b/helpdesk_scope/models/helpdesk_ticket.py
@@ -11,5 +11,5 @@ class HelpdeskTicket(models.Model):
 
     @api.onchange('team_id')
     def onchange_team_id(self):
-        if self.team_id:
+        if self.team_id not in self.scope_id.team_ids:
             self.scope_id = False


### PR DESCRIPTION
This PR changes the onchange method for teams by not clearing the scope field if that scope_id is on the helpdesk team that triggered the onchange.