### PR TITLE
[IMP] helpdesk_fieldservice: Add 'Service Orders' menu item (PM #576)

### DIFF
--- a/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
+++ b/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
@@ -45,4 +45,22 @@
             </field>
         </field>
     </record>
+
+    <menuitem id="menu_helpdesk_op"
+              name="Operations"
+              parent="helpdesk.menu_helpdesk_root"
+              sequence="10"/>
+
+    <menuitem id="menu_helpdesk_product"
+              name="Service Orders"
+              action="fieldservice.action_fsm_dash_order"
+              parent="menu_helpdesk_op"
+              sequence="20"/>
+
+    <data noupdate="1"><delete model="ir.ui.menu" id="helpdesk.helpdesk_ticket_menu_main"/></data>
+
+    <menuitem id="helpdesk_ticket_menu_main" 
+        action="helpdesk.helpdesk_ticket_action_main_tree"
+        sequence="10"
+        parent="menu_helpdesk_op"/>
 </odoo>

--- a/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
+++ b/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
@@ -51,7 +51,7 @@
               parent="helpdesk.menu_helpdesk_root"
               sequence="10"/>
 
-    <menuitem id="menu_helpdesk_product"
+    <menuitem id="menu_helpdesk_fsm_order"
               name="Service Orders"
               action="fieldservice.action_fsm_dash_order"
               parent="menu_helpdesk_op"

--- a/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
+++ b/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
@@ -57,10 +57,8 @@
               parent="menu_helpdesk_op"
               sequence="20"/>
 
-    <data noupdate="1"><delete model="ir.ui.menu" id="helpdesk.helpdesk_ticket_menu_main"/></data>
-
-    <menuitem id="helpdesk_ticket_menu_main" 
-        action="helpdesk.helpdesk_ticket_action_main_tree"
-        sequence="10"
+    <menuitem id="helpdesk.helpdesk_ticket_menu_main" 
+        name="All Tickets"
         parent="menu_helpdesk_op"/>
+
 </odoo>


### PR DESCRIPTION
This PR adds Service Orders to Helpdesk menu under the Operations parent menuitem. Also moves All Tickets menuitem under Operations parent as well.
Heirarchy:
Overview
Operations
*All Tickets
*Service Orders
Master Data
Reporting
Configuration