### PR TITLE
[IMP] helpdesk_fieldservice: Create Order Button (PM #550)

### DIFF
--- a/helpdesk_fieldservice/models/helpdesk_ticket.py
+++ b/helpdesk_fieldservice/models/helpdesk_ticket.py
@@ -58,3 +58,23 @@ class HelpdeskTicket(models.Model):
     def _onchange_partner_id_location(self):
         if self.partner_id:
             self._location_contact_fill(False)
+
+    @api.multi
+    def action_create_order(self):
+        '''
+        This function returns an action that displays a full FSM Order
+        form when creating an FSM Order from a ticket.
+        '''
+        action = self.env.ref('fieldservice.action_fsm_operation_order')
+        result = action.read()[0]
+        # override the context to get rid of the default filtering
+        result['context'] = {
+            'default_ticket_id': self.id,
+            'default_priority': self.priority,
+            'default_location_id': self.fsm_location_id.id,
+            'default_customer_id': self.partner_id.id
+        }
+        res = self.env.ref('fieldservice.fsm_order_form', False)
+        result['views'] = [(res and res.id or False, 'form')]
+        result['context']['default_origin'] = self.name
+        return result

--- a/helpdesk_fieldservice/models/helpdesk_ticket.py
+++ b/helpdesk_fieldservice/models/helpdesk_ticket.py
@@ -72,9 +72,9 @@ class HelpdeskTicket(models.Model):
             'default_ticket_id': self.id,
             'default_priority': self.priority,
             'default_location_id': self.fsm_location_id.id,
-            'default_customer_id': self.partner_id.id
+            'default_customer_id': self.partner_id.id,
+            'default_origin': self.name
         }
         res = self.env.ref('fieldservice.fsm_order_form', False)
         result['views'] = [(res and res.id or False, 'form')]
-        result['context']['default_origin'] = self.name
         return result

--- a/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
+++ b/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
@@ -44,6 +44,28 @@
         </field>
     </record>
 
+    <record id="helpdesk_ticket_tree_view_location" model="ir.ui.view">
+        <field name="name">helpdesk.ticket.tree.location</field>
+        <field name="model">helpdesk.ticket</field>
+        <field name="inherit_id" ref="helpdesk.helpdesk_tickets_view_tree"/>
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="fsm_location_id"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="helpdesk_ticket_search_view_location" model="ir.ui.view">
+        <field name="name">helpdesk.ticket.search.location</field>
+        <field name="model">helpdesk.ticket</field>
+        <field name="inherit_id" ref="helpdesk.helpdesk_tickets_view_search"/>
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="fsm_location_id"/>
+            </field>
+        </field>
+    </record>
+
     <menuitem id="menu_helpdesk_op"
               name="Operations"
               parent="helpdesk.menu_helpdesk_root"

--- a/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
+++ b/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
@@ -51,14 +51,16 @@
               parent="helpdesk.menu_helpdesk_root"
               sequence="10"/>
 
-    <menuitem id="menu_helpdesk_fsm_order"
+    <menuitem id="menu_helpdesk_product"
               name="Service Orders"
               action="fieldservice.action_fsm_dash_order"
               parent="menu_helpdesk_op"
               sequence="20"/>
 
-    <menuitem id="helpdesk.helpdesk_ticket_menu_main" 
-        name="All Tickets"
-        parent="menu_helpdesk_op"/>
+    <data noupdate="1"><delete model="ir.ui.menu" id="helpdesk.helpdesk_ticket_menu_main"/></data>
 
+    <menuitem id="helpdesk_ticket_menu_main" 
+        action="helpdesk.helpdesk_ticket_action_main_tree"
+        sequence="10"
+        parent="menu_helpdesk_op"/>
 </odoo>

--- a/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
+++ b/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
@@ -13,9 +13,8 @@
             <notebook position="inside">
                 <page string="Service Orders">
                     <field name="fsm_order_ids"
-                           context="{'default_customer_id': partner_id,
-                                     'default_location_id': fsm_location_id,
-                                     'default_priority': priority}">
+                           context="{'create_order':True}"
+                           readonly="1">
                         <tree>
                             <field name="name"/>
                             <field name="customer_id"/>
@@ -28,6 +27,9 @@
             <field name="partner_id" position="before">
                 <field name="fsm_location_id"/>
             </field>
+            <button name="assign_ticket_to_self" position="after">
+                <button name="action_create_order" string="Create FSM Order" type="object"/>
+            </button>
         </field>
     </record>
 

--- a/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
+++ b/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
@@ -57,10 +57,8 @@
               parent="menu_helpdesk_op"
               sequence="20"/>
 
-    <data noupdate="1"><delete model="ir.ui.menu" id="helpdesk.helpdesk_ticket_menu_main"/></data>
-
-    <menuitem id="helpdesk_ticket_menu_main" 
-        action="helpdesk.helpdesk_ticket_action_main_tree"
-        sequence="10"
+    <menuitem id="helpdesk.helpdesk_ticket_menu_main" 
+        name="All Tickets"
         parent="menu_helpdesk_op"/>
+
 </odoo>

--- a/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
+++ b/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
@@ -13,8 +13,7 @@
             <notebook position="inside">
                 <page string="Service Orders">
                     <field name="fsm_order_ids"
-                           context="{'create_order':True}"
-                           readonly="1">
+                           context="{'create_order':True}">
                         <tree>
                             <field name="name"/>
                             <field name="customer_id"/>

--- a/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
+++ b/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
@@ -12,6 +12,7 @@
         <field name="arch" type="xml">
             <notebook position="inside">
                 <page string="Service Orders">
+                    <button name="action_create_order" string="Create FSM Order" type="object" class="oe_highlight"/>
                     <field name="fsm_order_ids"
                            context="{'create_order':True}">
                         <tree>
@@ -26,9 +27,6 @@
             <field name="partner_id" position="before">
                 <field name="fsm_location_id"/>
             </field>
-            <button name="assign_ticket_to_self" position="after">
-                <button name="action_create_order" string="Create FSM Order" type="object"/>
-            </button>
         </field>
     </record>
 

--- a/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
+++ b/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
@@ -13,8 +13,7 @@
             <notebook position="inside">
                 <page string="Service Orders">
                     <button name="action_create_order" string="Create FSM Order" type="object" class="oe_highlight"/>
-                    <field name="fsm_order_ids"
-                           context="{'create_order':True}">
+                    <field name="fsm_order_ids">
                         <tree>
                             <field name="name"/>
                             <field name="customer_id"/>
@@ -50,7 +49,7 @@
               parent="helpdesk.menu_helpdesk_root"
               sequence="10"/>
 
-    <menuitem id="menu_helpdesk_product"
+    <menuitem id="menu_helpdesk_fsm_order"
               name="Service Orders"
               action="fieldservice.action_fsm_dash_order"
               parent="menu_helpdesk_op"


### PR DESCRIPTION
This PR adds a button labeled "Create FSM Order" that when clicked, pulls up a full screen form view of an FSM Order that is tied back to the fsm_order_ids on a Helpdesk Ticket.

EDIT: Added FSM Locations to Search and List View on Tickets