### PR TITLE
[IMP] helpdesk_fieldservice: Add View Order Button

### DIFF
--- a/helpdesk_fieldservice/models/fsm_order.py
+++ b/helpdesk_fieldservice/models/fsm_order.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 _logger = logging.getLogger(__name__)
 
@@ -13,3 +13,17 @@ class FSMOrder(models.Model):
 
     ticket_id = fields.Many2one('helpdesk.ticket', string='Ticket',
                                 track_visibility='onchange')
+
+    @api.multi
+    def action_view_order(self):
+        '''
+        This function returns an action that displays a full FSM Order
+        form when viewing an FSM Order from a ticket.
+        '''
+        action = self.env.ref('fieldservice.action_fsm_operation_order').\
+            read()[0]
+        order = self.env['fsm.order'].search([('id', '=', self.id)])
+        action['views'] = [(self.env.ref('fieldservice.' +
+                                         'fsm_order_form').id, 'form')]
+        action['res_id'] = order.id
+        return action

--- a/helpdesk_fieldservice/static/src/scss/helpdesk_column.scss
+++ b/helpdesk_fieldservice/static/src/scss/helpdesk_column.scss
@@ -1,0 +1,6 @@
+.helpdesk_column {
+        width: 100% !important;
+        color: white;
+        background-color: $o-brand-primary;
+        text-transform: uppercase;
+}

--- a/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
+++ b/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
@@ -25,6 +25,8 @@
                             <field name="location_id" style="pointer-events:none;"/>
                             <button name="action_view_order" string="View FSM Order" type="object" class="helpdesk_column"/>
                             <field name="stage_id" style="pointer-events:none;"/>
+                            <field name="person_id" style="pointer-events:none;"/>
+                            <field name="scheduled_date_start" style="pointer-events:none;"/>
                         </tree>
                     </field>
                 </page>

--- a/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
+++ b/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
@@ -2,7 +2,7 @@
 <odoo>
     <!-- Copyright 2019 Open Source Integrators
          License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
-    <template id="shrink_tree_column" name="account assets" inherit_id="web.assets_backend">
+    <template id="shrink_tree_column" name="helpdesk assets" inherit_id="web.assets_backend">
         <xpath expr="." position="inside">
             <link rel="stylesheet" href="helpdesk_fieldservice/static/src/scss/helpdesk_column.scss"/>
         </xpath>

--- a/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
+++ b/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
@@ -2,6 +2,11 @@
 <odoo>
     <!-- Copyright 2019 Open Source Integrators
          License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
+    <template id="shrink_tree_column" name="account assets" inherit_id="web.assets_backend">
+        <xpath expr="." position="inside">
+            <link rel="stylesheet" href="helpdesk_fieldservice/static/src/scss/helpdesk_column.scss"/>
+        </xpath>
+    </template>
 
     <!-- Helpdesk Ticket Form View -->
     <record id="helpdesk_ticket_view_service_request_form" model="ir.ui.view">
@@ -15,10 +20,11 @@
                     <button name="action_create_order" string="Create FSM Order" type="object" class="oe_highlight"/>
                     <field name="fsm_order_ids">
                         <tree>
-                            <field name="name"/>
-                            <field name="customer_id"/>
-                            <field name="location_id"/>
-                            <field name="stage_id"/>
+                            <field name="name" style="pointer-events:none;"/>
+                            <field name="customer_id" style="pointer-events:none;"/>
+                            <field name="location_id" style="pointer-events:none;"/>
+                            <button name="action_view_order" string="View FSM Order" type="object" class="helpdesk_column"/>
+                            <field name="stage_id" style="pointer-events:none;"/>
                         </tree>
                     </field>
                 </page>


### PR DESCRIPTION
Added button to open full view of record in One2many list of fsm_orders. Disabled JS pointer on all columns of the tree view except the button so they cannot be clicked. Made a new scss class so the button took up the entire space of its column on the tree because any open space in that column could be clicked on and it would open the popup view. 