### PR TITLE
[IMP] helpdesk_fieldservice: Fields on Ticket Service Order Tree

### DIFF
--- a/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
+++ b/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
@@ -27,6 +27,8 @@
                             <field name="stage_id" style="pointer-events:none;"/>
                             <field name="person_id" style="pointer-events:none;"/>
                             <field name="scheduled_date_start" style="pointer-events:none;"/>
+                            <field name="scheduled_date_end" style="pointer-events:none;"/>
+                            <field name="scheduled_duration" style="pointer-events:none;"/>
                         </tree>
                     </field>
                 </page>


### PR DESCRIPTION
Users wanted to see scheduled date end and scheduled duration added to FSM Orders list view on Tickets