### PR TITLE
[FIX] helpdesk_team_assigned_tickets: Overwrite Active ID

### DIFF
--- a/helpdesk_team_assigned_tickets/views/helpdesk_team.xml
+++ b/helpdesk_team_assigned_tickets/views/helpdesk_team.xml
@@ -43,4 +43,15 @@
         </field>
     </record>
 
+    <record id="helpdesk_ticket_active_id" model="ir.ui.view">
+        <field name="name">helpdesk.ticket.active.id</field>
+        <field name="model">helpdesk.ticket</field>
+        <field name="inherit_id" ref="helpdesk.helpdesk_ticket_view_form"/>
+        <field name="arch" type="xml">
+            <field name="stage_id" position="attributes">
+                <attribute name="context">{'active_id': id, 'active_ids': [id], 'active_model': 'helpdesk.ticket'}</attribute>
+            </field>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
When you select a helpdesk team it takes you to the dashboard with that teams filter in the search bar. If you notice in the url, the active_id is equal to the id of the helpdesk team. When you select a ticket, the active_id is not changed to that ticket. This creates a problem when trying to send emails from a ticket because the active_id and active_model does not match the ticket. This PR fixes that issue by restoring the proper fields to the context when the ticket is created and the stage is set.