### PR TITLE
[IMP] helpdesk_fieldservice: Default Search Open Tickets

### DIFF
--- a/helpdesk_fieldservice/models/fsm_location.py
+++ b/helpdesk_fieldservice/models/fsm_location.py
@@ -33,4 +33,5 @@ class FSMLocation(models.Model):
                 action['res_id'] = ticket_ids.ids[0]
             else:
                 action['domain'] = [('id', 'in', ticket_ids.ids)]
+                action['context'].update({'search_default_is_open': 1})
             return action


### PR DESCRIPTION
Set the default search filter to only show open tickets when viewing tickets for a location. 