### PR TITLE
[FIX] osi_payment_method: Onchange Partner ID

### DIFF
--- a/osi_payment_method/models/account_invoice.py
+++ b/osi_payment_method/models/account_invoice.py
@@ -19,7 +19,9 @@ class AccountInvoice(models.Model):
 
     @api.onchange('partner_id')
     def _onchange_partner_id(self):
+        res = super(AccountInvoice, self)._onchange_partner_id()
         self.payment_method = self.partner_id.payment_method
+        return res
 
     # Load all unsold PO lines
     @api.onchange('purchase_id')

--- a/osi_payment_method/models/account_invoice.py
+++ b/osi_payment_method/models/account_invoice.py
@@ -19,7 +19,7 @@ class AccountInvoice(models.Model):
 
     @api.onchange('partner_id')
     def _onchange_partner_id(self):
-        res = super(AccountInvoice, self)._onchange_partner_id()
+        res = super()._onchange_partner_id()
         self.payment_method = self.partner_id.payment_method
         return res
 


### PR DESCRIPTION
Call super() for _onchange_partner_id() so we do not overwrite base _onchange_partner_id functionality.