### PR TITLE
[IMP] helpdesk_fieldservice: Filter Tickets with Closed Orders

### DIFF
--- a/helpdesk_fieldservice/models/helpdesk_ticket.py
+++ b/helpdesk_fieldservice/models/helpdesk_ticket.py
@@ -88,7 +88,7 @@ class HelpdeskTicket(models.Model):
             ticket.all_orders_closed = True
             if ticket.fsm_order_ids:
                 for order in ticket.fsm_order_ids:
-                    if order.stage_id.name not in  ['Closed', 'Cancelled']:
+                    if order.stage_id.name not in ['Closed', 'Cancelled']:
                         ticket.all_orders_closed = False
             else:
-                ticket.all_orders_closed = False                
+                ticket.all_orders_closed = False

--- a/helpdesk_fieldservice/models/helpdesk_ticket.py
+++ b/helpdesk_fieldservice/models/helpdesk_ticket.py
@@ -12,6 +12,9 @@ class HelpdeskTicket(models.Model):
                                     string='Service Orders')
     fsm_location_id = fields.Many2one('fsm.location', string='FSM Location')
 
+    all_orders_closed = fields.Boolean(compute='_compute_all_closed',
+                                       store=True)
+
     @api.multi
     def write(self, vals):
         if 'stage_id' in vals:
@@ -78,3 +81,11 @@ class HelpdeskTicket(models.Model):
         res = self.env.ref('fieldservice.fsm_order_form', False)
         result['views'] = [(res and res.id or False, 'form')]
         return result
+
+    @api.depends('fsm_order_ids', 'stage_id', 'fsm_order_ids.stage_id')
+    def _compute_all_closed(self):
+        for ticket in self:
+            ticket.all_orders_closed = True
+            for order in ticket.fsm_order_ids:
+                if order.stage_id.name not in  ['Closed', 'Cancelled']:
+                    ticket.all_orders_closed = False

--- a/helpdesk_fieldservice/models/helpdesk_ticket.py
+++ b/helpdesk_fieldservice/models/helpdesk_ticket.py
@@ -91,4 +91,4 @@ class HelpdeskTicket(models.Model):
                     if order.stage_id.name not in  ['Closed', 'Cancelled']:
                         ticket.all_orders_closed = False
             else:
-                ticket.all_orders_closed = False                
+                ticket.all_orders_closed = False

--- a/helpdesk_fieldservice/models/helpdesk_ticket.py
+++ b/helpdesk_fieldservice/models/helpdesk_ticket.py
@@ -86,6 +86,9 @@ class HelpdeskTicket(models.Model):
     def _compute_all_closed(self):
         for ticket in self:
             ticket.all_orders_closed = True
-            for order in ticket.fsm_order_ids:
-                if order.stage_id.name not in  ['Closed', 'Cancelled']:
-                    ticket.all_orders_closed = False
+            if ticket.fsm_order_ids:
+                for order in ticket.fsm_order_ids:
+                    if order.stage_id.name not in  ['Closed', 'Cancelled']:
+                        ticket.all_orders_closed = False
+            else:
+                ticket.all_orders_closed = False                

--- a/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
+++ b/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
@@ -35,7 +35,19 @@
             </notebook>
             <field name="partner_id" position="before">
                 <field name="fsm_location_id"/>
+                <field name="all_orders_closed" invisible="1"/>
             </field>
+        </field>
+    </record>
+
+    <record id="helpdesk_ticket_search_closed_orders" model="ir.ui.view">
+        <field name="name">helpdesk.ticket.service.form.logic</field>
+        <field name="model">helpdesk.ticket</field>
+        <field name="inherit_id" ref="helpdesk.helpdesk_tickets_view_search"/>
+        <field name="arch" type="xml">
+            <filter name="is_close" position="after">
+                <filter string="Closed Orders" domain="[('stage_id.is_close', '=', False),('all_orders_closed', '=', True)]" name="closed_fsm_order"/>
+            </filter>
         </field>
     </record>
 

--- a/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
+++ b/helpdesk_fieldservice/views/helpdesk_ticket_views.xml
@@ -46,7 +46,7 @@
         <field name="inherit_id" ref="helpdesk.helpdesk_tickets_view_search"/>
         <field name="arch" type="xml">
             <filter name="is_close" position="after">
-                <filter string="Closed Orders" domain="[('stage_id.is_close', '=', False),('all_orders_closed', '=', True)]" name="closed_fsm_order"/>
+                <filter string="Closed FSM Orders" domain="[('stage_id.is_close', '=', False), ('all_orders_closed', '=', True)]" name="closed_fsm_order"/>
             </filter>
         </field>
     </record>


### PR DESCRIPTION
This PR adds a filter that shows Helpdesk Tickets who have Service Requests but those Service Requests are all in 'Closed' or 'Cancelled' state.