### PR TITLE
[FIX] agreement_sale_subscription: Agreement Not Set on Subscription From Sale Order

### DIFF
--- a/agreement_sale_subscription/README.rst
+++ b/agreement_sale_subscription/README.rst
@@ -36,10 +36,11 @@ The roadmap and issues are documented at https://github.cim/ursais/osi-addons/is
 Credits
 =======
 
-* Steve Campbell <scampbell@opensourceintegrators.com>
+* Open Source Integrators <contact@opensourceintegrators.com>
 
 Contributors
 ------------
 
-* Open Source Integrators <contact@opensourceintegrators.com>
+* Steve Campbell <scampbell@opensourceintegrators.com>
 * Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
+* Bhavesh Odedra <bodedra@opensourceintegrators.com>

--- a/agreement_sale_subscription/__manifest__.py
+++ b/agreement_sale_subscription/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Agreement - Sales Subscription',
     'summary': 'Link your sales subscriptions to an agreement',
-    'version': '12.0.1.1.0',
+    'version': '12.0.1.0.1',
     'license': 'LGPL-3',
     'author': 'Open Source Integrators',
     'category': 'Agreement',

--- a/agreement_sale_subscription/__manifest__.py
+++ b/agreement_sale_subscription/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Agreement - Sales Subscription',
     'summary': 'Link your sales subscriptions to an agreement',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.1.0',
     'license': 'LGPL-3',
     'author': 'Open Source Integrators',
     'category': 'Agreement',

--- a/agreement_sale_subscription/models/sale_order.py
+++ b/agreement_sale_subscription/models/sale_order.py
@@ -7,15 +7,13 @@ from odoo import api, models
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
-    @api.multi
-    def create_subscriptions(self):
-        res = super().create_subscriptions()
+
+    def _action_confirm(self):
+        res = super()._action_confirm()
         for order in self:
             for line in order.order_line:
                 if line.subscription_id and order.agreement_id:
-                    # Set the subscription on the agreement
                     order.agreement_id.subscription_id = \
                         line.subscription_id.id
-                    # Set the agreement on the subscription
-                    line.subscription_id.agreement_id = order.agreement_id.id
+                    line.subscription_id.agreement_id = order.agreement_id
         return res

--- a/agreement_sale_subscription/models/sale_order.py
+++ b/agreement_sale_subscription/models/sale_order.py
@@ -14,5 +14,6 @@ class SaleOrder(models.Model):
                 if line.subscription_id and order.agreement_id:
                     order.agreement_id.subscription_id = \
                         line.subscription_id.id
-                    line.subscription_id.agreement_id = order.agreement_id
+                    line.subscription_id.agreement_id = \
+                        order.agreement_id.id
         return res

--- a/agreement_sale_subscription/models/sale_order.py
+++ b/agreement_sale_subscription/models/sale_order.py
@@ -1,19 +1,17 @@
 # Copyright (C) 2019 - TODAY, Open Source Integrators
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from odoo import models
+from odoo import api, models
 
 
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
+    @api.multi
     def _action_confirm(self):
         res = super()._action_confirm()
-        for order in self:
-            for line in order.order_line:
-                if line.subscription_id and order.agreement_id:
-                    order.agreement_id.subscription_id = \
-                        line.subscription_id.id
-                    line.subscription_id.agreement_id = \
-                        order.agreement_id.id
+        for order in self.filtered(lambda x: x.agreement_id):
+            for line in order.order_line.filtered(lambda l: l.subscription_id):
+                order.agreement_id.subscription_id = line.subscription_id.id
+                line.subscription_id.agreement_id = order.agreement_id.id
         return res

--- a/agreement_sale_subscription/models/sale_order.py
+++ b/agreement_sale_subscription/models/sale_order.py
@@ -1,12 +1,11 @@
 # Copyright (C) 2019 - TODAY, Open Source Integrators
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from odoo import api, models
+from odoo import models
 
 
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
-
 
     def _action_confirm(self):
         res = super()._action_confirm()


### PR DESCRIPTION
When creating a Subscription from a Sale Order with an Agreement Template on it, the Agreement was created sucessfully and put on the Sale Order, however it is not being put on the Subscription. I believe this is because the we are setting the Agreement on the Subscription in the create_subscription() method which is called before we set the Agreement on the Sale Order. By moving the functionality to the _action_confirm() method, we can ensure the Agreement is made and set on the Sale Order before we set it on the Subscription.

STEPS TO REPRODUCE:
Install agreement_sale_subscription
Create Sale Order with Agreement Template and 1 Subscription Product
Confirm Sale Order
Notice the Agreement is not add to the Subscription