### PR TITLE
[IMP] helpdesk_stock: Don't Overwrite Existing Group

### DIFF
--- a/helpdesk_stock/models/stock_request_order.py
+++ b/helpdesk_stock/models/stock_request_order.py
@@ -43,7 +43,7 @@ class StockRequestOrder(models.Model):
 
     @api.multi
     def _action_confirm(self):
-        if self.helpdesk_ticket_id:
+        if self.helpdesk_ticket_id and not self.procurement_group_id:
             ticket = self.env['helpdesk.ticket'].browse(
                 self.helpdesk_ticket_id.id)
             group = self.env['procurement.group'].search([


### PR DESCRIPTION
We do not want to overwrite an existing procurement_group if one has already been generated (from fieldservice_stock). 

If you installed fsm_stock and then helpdesk_stock, this code would overwrite the procurement_group made by the fsm_order which we do not want.