### PR TITLE
[FIX] sale_subscription_financial_risk

### DIFF
--- a/sale_subscription_financial_risk/models/account_invoice.py
+++ b/sale_subscription_financial_risk/models/account_invoice.py
@@ -15,9 +15,8 @@ class AccountInvoice(models.Model):
     def write(self, vals):
         # If we aren't writing to 'state' in this call, maintain 'false'
         run_suspension_check = False
-        # If we are writing to 'state' to value 'paid' or 'in_payment', then
-        # run the suspend check
-        if vals.get('state', False) in ['paid', 'in_payment']:
+        # If we are writing to 'state' to value 'paid', run the suspend check
+        if vals.get('state', False) == 'paid':
             run_suspension_check = True
         # update the variable
         vals.update({'run_suspension_check': run_suspension_check})

--- a/sale_subscription_financial_risk/models/account_invoice.py
+++ b/sale_subscription_financial_risk/models/account_invoice.py
@@ -15,8 +15,9 @@ class AccountInvoice(models.Model):
     def write(self, vals):
         # If we aren't writing to 'state' in this call, maintain 'false'
         run_suspension_check = False
-        # If we are writing to 'state' to value 'paid', run the suspend check
-        if vals.get('state', False) == 'paid':
+        # If we are writing to 'state' to value 'paid' or 'in_payment', then
+        # run the suspend check
+        if vals.get('state', False) in ['paid', 'in_payment']:
             run_suspension_check = True
         # update the variable
         vals.update({'run_suspension_check': run_suspension_check})

--- a/sale_subscription_financial_risk/models/sale_subscription.py
+++ b/sale_subscription_financial_risk/models/sale_subscription.py
@@ -6,12 +6,17 @@ from dateutil.relativedelta import relativedelta
 from odoo import api, models, _
 from odoo.exceptions import UserError
 
+import logging
+
+_logger = logging.getLogger(__name__)
+
 
 class SaleSubscription(models.Model):
     _inherit = 'sale.subscription'
 
     # Calculates and returns a timedelta based on the customer's credit terms
     def _get_delta_qty(self, qty, uom):
+        _logger.info("jacob called _get_delta_qty")
         if uom == 'days':
             delta_qty = timedelta(days=qty)
         elif uom == 'weeks':
@@ -20,13 +25,16 @@ class SaleSubscription(models.Model):
             delta_qty = relativedelta(months=qty)
         elif uom == 'years':
             delta_qty = relativedelta(years=qty)
+        _logger.info("Jacob delta_qty is {}".format(delta_qty))
         return delta_qty
 
     # May be called by an account.invoice onchange/payment received or
     # by the batch loop cron sale_subscription_financial_risk_suspend.xml
     @api.model
     def check_service_suspensions(self):
+        _logger.info("Jacob called check_service_suspensions")
         for subscription in self:
+            _logger.info("Jacob checking partner name {}".format(subscription.partner_id.name))
             try:
                 # get list of open invoices, sorted by oldest open
                 open_invoices = self.env['account.invoice'].search(
@@ -43,11 +51,12 @@ class SaleSubscription(models.Model):
                     subscription.partner_id.overdue_limit_qty,
                     subscription.partner_id.overdue_limit_uom)
                 if open_invoices:
+                    _logger.info("Jacob found open invoices for parnter")
                     # Compute their credit and their credit limit based on type
                     # Using the oldest open invoice
                     # Inspected fixed credit based limits
                     if subscription.partner_id.credit_limit_type == 'fixed':
-
+                        _logger.info("Jacob confirmed credit_limit_type == Fixed")
                         # format the credit float to prevent precision error
                         formatted_credit = format(
                             subscription.partner_id.credit, '.2f')
@@ -55,18 +64,23 @@ class SaleSubscription(models.Model):
                         # Check for violation by credit limit
                         if float(formatted_credit) > subscription.\
                                 partner_id.credit_limit:
+                            _logger.info("Jacob suspending because credit limit amount is exceeded")
                             subscription.action_suspend()
                         # Check for violation by invoice age
                         elif open_invoices[0].date_due + delta_qty < cur_date:
+                            _logger.info("Jacob suspending because invoice date is past allowable days")
                             subscription.action_suspend()
                         # Otherwise, re-activate everything if suspended
                         elif subscription.stage_id.id == \
                                 suspended_stage_id:
+                            _logger.info("Jacob re-activating service")
                             subscription.action_re_activate()
+                        _logger.info("Jacob no action was taken")
 
                     # Inspecting subscription-based credit limits
                     elif subscription.partner_id.credit_limit_type == \
                             'subscription_based':
+                        _logger.info("Jacob confirmed credit_limit_type == Subscription")
 
                         delta_mod = subscription._get_delta_qty(
                             subscription.partner_id.
@@ -91,14 +105,17 @@ class SaleSubscription(models.Model):
 
                         # Check state of violation; if True, suspend
                         if suspend:
+                            _logger.info("Jacob suspending subscription service")
                             subscription.action_suspend()
                         # If violation false and subscription is suspended
                         # Then activate it
                         elif subscription.stage_id.id == suspended_stage_id:
+                            _logger.info("Jacob re-activating subscription service")
                             subscription.action_re_activate()
 
                 # Else there are no open invoices, verify services are active
                 elif subscription.stage_id.id == suspended_stage_id:
+                    _logger.info("Jacob no open invoices, re-activating service")
                     subscription.action_re_activate()
 
             except RuntimeError as error:


### PR DESCRIPTION
Added the account.invoice *state* field value _in_payment_ as as a valid state for running the run_suspension_check() function upon payment receipt.

This *state* value was overlooked when creating the initial function but should be included - it is triggered under certain payment receipt types (e.g. when registering a checking account payment).

The balance of invoices in *state* _in_payment_ do not count against the partner's calculated risk, so this should allow the partner subscriptions and service profiles to re-activate as intended.