### PR TITLE
[IMP] fieldservice_account_asset: Fix Error On Install

### DIFF
--- a/fieldservice_account_asset/models/res_company.py
+++ b/fieldservice_account_asset/models/res_company.py
@@ -9,7 +9,7 @@ class ResCompany(models.Model):
     _inherit = 'res.company'
 
     def _default_asset_location_id(self):
-        return self.env.ref('fieldservice_account_asset.asset_location')
+        return self.env.ref('fieldservice_account_asset.asset_location', False)
 
     asset_location_id = fields.Many2one(
         'stock.location', string='Asset Location',


### PR DESCRIPTION
Upon installation, the default field is attempting to be set before the xml is loaded in causing an error on installation. Was confirmed by myself, Mike, and Amplex. This PR searches for the xml field after it has been loaded in.