### PR TITLE
[IMP] Add Account Voucher to Depends

### DIFF
--- a/osi_credit_card_reconciliation/__manifest__.py
+++ b/osi_credit_card_reconciliation/__manifest__.py
@@ -13,6 +13,7 @@
     "depends": [
         'account_accountant',
         'account_payment_credit_card',
+        'account_voucher'
     ],
     "data": [
         "security/credit_card_reconciliation_security.xml",


### PR DESCRIPTION
Installing osi_credit_card_reconciliation without account_voucher installed throws an error on installation. This PR adds account_voucher to the "depends"

```
File "/opt/odoo/odoo/odoo/addons/base/models/ir_actions.py", line 141, in _check_model
    raise ValidationError(_('Invalid model name %r in action definition.') % action.res_model)
odoo.tools.convert.ParseError: "Invalid model name 'account.voucher' in action definition.
None" while parsing /opt/odoo/src/osi-addons/osi_credit_card_reconciliation/views/cc_rec_statement_view.xml:296, near
<act_window id="act_supplier_payment_to_add_cc" name="Supplier Payment" domain="[('journal_id.type', 'in', ['bank', 'cash']), ('type','=','receipt')]" context="{'type':'payment'}" res_model="account.voucher" src_model="cc.rec.statement"/>
```

Ticket #1232