### PR TITLE
[IMP] Customer Context + Same Rules As Helpdesk

### DIFF
--- a/helpdesk_fieldservice/models/helpdesk_ticket.py
+++ b/helpdesk_fieldservice/models/helpdesk_ticket.py
@@ -75,7 +75,8 @@ class HelpdeskTicket(models.Model):
             'default_ticket_id': self.id,
             'default_priority': self.priority,
             'default_location_id': self.fsm_location_id.id,
-            'default_origin': self.name
+            'default_origin': self.name,
+            'default_customer_id': self.partner_id.id
         }
         res = self.env.ref('fieldservice.fsm_order_form', False)
         result['views'] = [(res and res.id or False, 'form')]


### PR DESCRIPTION
This PR passes customer_id into the context when creating an FSO from a HT. We also apply the same rules on HT's to FSO's in terms of contact/location relationship