### PR TITLE
[FIX] fieldservice_agreement_helpdesk: Ticket -> FSO: Agreement Context

### DIFF
--- a/fieldservice_agreement_helpdesk/models/__init__.py
+++ b/fieldservice_agreement_helpdesk/models/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 - TODAY, Open Source Integrators
+# Copyright (C) 2019 Open Source Integrators
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from . import helpdesk_ticket

--- a/fieldservice_agreement_helpdesk/models/__init__.py
+++ b/fieldservice_agreement_helpdesk/models/__init__.py
@@ -1,2 +1,4 @@
 # Copyright (C) 2019 - TODAY, Open Source Integrators
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import helpdesk_ticket

--- a/fieldservice_agreement_helpdesk/models/helpdesk_ticket.py
+++ b/fieldservice_agreement_helpdesk/models/helpdesk_ticket.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2019, Open Source Integrators
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import api, models
+
+
+class HelpdeskTicket(models.Model):
+    _inherit = 'helpdesk.ticket'
+
+    @api.multi
+    def action_create_order(self):
+        import pdb; pdb.set_trace()
+        res = super().action_create_order()
+        '''
+        This function returns an action that displays a full FSM Order
+        form when creating an FSM Order from a ticket.
+        '''
+        # override the context to get rid of the default filtering
+        res['context'] = {
+            'default_agreement_id': self.agreement_id.id,
+            'default_serviceprofile_id': self.serviceprofile_id.id,
+        }
+        return res

--- a/fieldservice_agreement_helpdesk/models/helpdesk_ticket.py
+++ b/fieldservice_agreement_helpdesk/models/helpdesk_ticket.py
@@ -9,11 +9,11 @@ class HelpdeskTicket(models.Model):
 
     @api.multi
     def action_create_order(self):
-        res = super().action_create_order()
-        '''
+        """
         This function returns an action that displays a full FSM Order
         form when creating an FSM Order from a ticket.
-        '''
+        """
+        res = super().action_create_order()
         # override the context to get rid of the default filtering
         res['context'] = {
             'default_agreement_id': self.agreement_id.id,

--- a/fieldservice_agreement_helpdesk/models/helpdesk_ticket.py
+++ b/fieldservice_agreement_helpdesk/models/helpdesk_ticket.py
@@ -1,6 +1,5 @@
-# Copyright (C) 2019, Open Source Integrators
+# Copyright (C) 2019 Open Source Integrators
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
-
 from odoo import api, models
 
 

--- a/fieldservice_agreement_helpdesk/models/helpdesk_ticket.py
+++ b/fieldservice_agreement_helpdesk/models/helpdesk_ticket.py
@@ -9,7 +9,6 @@ class HelpdeskTicket(models.Model):
 
     @api.multi
     def action_create_order(self):
-        import pdb; pdb.set_trace()
         res = super().action_create_order()
         '''
         This function returns an action that displays a full FSM Order

--- a/fieldservice_agreement_helpdesk/views/helpdesk_ticket.xml
+++ b/fieldservice_agreement_helpdesk/views/helpdesk_ticket.xml
@@ -9,15 +9,6 @@
         <field name="model">helpdesk.ticket</field>
         <field name="inherit_id" ref="helpdesk.helpdesk_ticket_view_form"/>
         <field name="arch" type="xml">
-            <field name="fsm_order_ids" position="attributes">
-                <attribute name="context">{
-                    'default_customer_id': partner_id,
-                    'default_location_id': fsm_location_id,
-                    'default_priority': priority,
-                    'default_agreement_id': agreement_id,
-                    'default_serviceprofile_id': serviceprofile_id
-                    }</attribute>
-            </field>
             <field name="agreement_id" position="attributes">
                 <attribute name="domain">[
                     '|',


### PR DESCRIPTION
The following PR adds to the context by extending the method from helpdesk_fieldservice by carrying over agreement_id and serviceprofile_id. Remove unneccesary XML