### PR TITLE
[FIX] fieldservice_agreement_helpdesk: Update Context Not Overwrite

### DIFF
--- a/fieldservice_agreement_helpdesk/models/helpdesk_ticket.py
+++ b/fieldservice_agreement_helpdesk/models/helpdesk_ticket.py
@@ -14,8 +14,8 @@ class HelpdeskTicket(models.Model):
         """
         res = super().action_create_order()
         # override the context to get rid of the default filtering
-        res['context'] = {
+        res['context'].update({
             'default_agreement_id': self.agreement_id.id,
             'default_serviceprofile_id': self.serviceprofile_id.id,
-        }
+        })
         return res

--- a/helpdesk_fieldservice/views/fsm_order_views.xml
+++ b/helpdesk_fieldservice/views/fsm_order_views.xml
@@ -8,10 +8,7 @@
         <field name="inherit_id" ref="fieldservice.fsm_order_form"/>
         <field name="arch" type="xml">
             <field name="template_id" position="after">
-                <field name="ticket_id" context="{'default_ticket_id': active_id}"/>
-            </field>
-            <field name="priority" position="attributes">
-                <attribute name="context">{'default_priority': priority}</attribute>
+                <field name="ticket_id"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Update Context instead of overwriting it. Remove unnecessary xml.