### PR TITLE
[ADD] Subscriptions: variable amount lines on recurring invoices

### DIFF
--- a/sale_subscription_invoice_variable/README.rst
+++ b/sale_subscription_invoice_variable/README.rst
@@ -1,0 +1,38 @@
+.. image:: https://img.shields.io/badge/licence-LGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/lgpl-3.0-standalone.html
+   :alt: License: LGPL-3
+
+===============================
+Subscription Variable Invoicing
+===============================
+
+Include variable consumed amount in recurring bills.
+
+The Subscription must have an Analytic Account, and
+the additional consumptions should be recorded as Analytic Lines.
+
+When the recurring invoice is being generated,
+we look for the amounts in Analytic Lines
+matching the Analytic Accountand the dates of the invoicing period.
+
+These will be added to the generated invoice.
+
+
+Usage
+=====
+
+* On the Subscription, ensure the Analytic Account is set.
+* Add the amaount to invoice as Analytic Lines.
+* Generated the next recurring invoice.
+
+
+Credits
+=======
+
+* Daniel Reis <dreis@opensourceintegrators.com>
+
+
+Contributors
+------------
+
+* Open Source Integrators <https://www.opensourceintegrators.com>

--- a/sale_subscription_invoice_variable/__init__.py
+++ b/sale_subscription_invoice_variable/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2019, Open Source Integrators
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import models

--- a/sale_subscription_invoice_variable/__manifest__.py
+++ b/sale_subscription_invoice_variable/__manifest__.py
@@ -12,5 +12,8 @@
     'depends': [
         'sale_subscription',
     ],
+    'data': [
+        'views/sale_subscription_views.xml',
+    ],
     'installable': True,
 }

--- a/sale_subscription_invoice_variable/__manifest__.py
+++ b/sale_subscription_invoice_variable/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2019, Open Source Integrators
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+{
+    'name': 'Subscription Variable Invoicing',
+    'summary': 'Include variable consumed amount in recurring bills',
+    'version': '12.0.1.0.0',
+    'license': 'LGPL-3',
+    'author': 'Open Source Integrators',
+    'category': 'Sales',
+    'website': 'https://github.com/ursais/osi-addons',
+    'depends': [
+        'sale_subscription',
+    ],
+    'installable': True,
+}

--- a/sale_subscription_invoice_variable/models/__init__.py
+++ b/sale_subscription_invoice_variable/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2019, Open Source Integrators
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import sale_subscription

--- a/sale_subscription_invoice_variable/models/__init__.py
+++ b/sale_subscription_invoice_variable/models/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2019, Open Source Integrators
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
+from . import sale_order
 from . import sale_subscription

--- a/sale_subscription_invoice_variable/models/sale_order.py
+++ b/sale_subscription_invoice_variable/models/sale_order.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2019, Open Source Integrators
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from datetime import date, timedelta
+from odoo import api, fields, models
+
+
+class SaleOrder(models.Model):
+
+    _inherit = 'sale.order'
+
+    def _prepare_subscription_data(self, template):
+        """
+        Fix possible Odoo bug:
+        the initial next invoice date should be now,
+        not next month
+        """
+        res = super()._prepare_subscription_data(template)
+        res['recurring_next_date'] = res['date_start']
+        return res

--- a/sale_subscription_invoice_variable/models/sale_order.py
+++ b/sale_subscription_invoice_variable/models/sale_order.py
@@ -1,8 +1,7 @@
 # Copyright (C) 2019, Open Source Integrators
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from datetime import date, timedelta
-from odoo import api, fields, models
+from odoo import models
 
 
 class SaleOrder(models.Model):

--- a/sale_subscription_invoice_variable/models/sale_subscription.py
+++ b/sale_subscription_invoice_variable/models/sale_subscription.py
@@ -25,7 +25,7 @@ class SaleSubscription(models.Model):
     def _prepare_invoice_variable_name(self, analytic_line):
         """Returns the description to use for the invoice line"""
         self.ensure_one()
-        return analytic_line.product_id.name
+        return analytic_line.product_id.display_name
 
     @api.model
     def _prepare_invoice_analytic_domain(self, start_date, end_date):

--- a/sale_subscription_invoice_variable/models/sale_subscription.py
+++ b/sale_subscription_invoice_variable/models/sale_subscription.py
@@ -1,8 +1,8 @@
 # Copyright (C) 2019, Open Source Integrators
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from datetime import date, timedelta
-from odoo import api, fields, models
+from datetime import timedelta
+from odoo import models
 
 
 class SaleSubscription(models.Model):

--- a/sale_subscription_invoice_variable/models/sale_subscription.py
+++ b/sale_subscription_invoice_variable/models/sale_subscription.py
@@ -1,8 +1,8 @@
 # Copyright (C) 2019, Open Source Integrators
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from datetime import timedelta
-from odoo import models
+from datetime import date, timedelta
+from odoo import api, fields, models
 
 
 class SaleSubscription(models.Model):

--- a/sale_subscription_invoice_variable/models/sale_subscription.py
+++ b/sale_subscription_invoice_variable/models/sale_subscription.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2019, Open Source Integrators
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from dateutil.relativedelta import relativedelta
+from odoo import models, api
+
+
+class SaleSubscription(models.Model):
+
+    _inherit = 'sale.subscription'
+
+    def _prepare_invoice_variable_dates(self):
+        """
+        The dates for the previous billing period.
+        Based on the implementation of _prepare_invoice_data().
+        """
+        self.ensure_one()
+        next_date = fields.Date.from_string(self.recurring_next_date)
+        if not next_date:
+            raise UserError(
+                _('Please define Date of Next Invoice of "%s".')
+                % (self.display_name,))
+        periods = {
+            'daily': 'days', 'weekly': 'weeks',
+            'monthly': 'months', 'yearly': 'years'}
+        start_date = next_date - relativedelta(
+            **{periods[self.recurring_rule_type]: self.recurring_interval})
+        end_date = next_date - relativedelta(days=1)
+        return start_date, end_date
+
+    @api.model
+    def _prepare_invoice_variable_name(self, analytic_line):
+        """Returns the description to use for the invoice line"""
+        return analytic_line.product_id.name
+
+    def _prepare_invoice_lines(self, fiscal_position):
+        res = super()._prepare_invoice_lines(fiscal_position)
+        import pudb; pu.db
+
+        self.ensure_one()
+        Analytic = self.env['account.analytic.line']
+        FiscalPos = self.env['account.fiscal.position']
+        fiscal_position = FiscalPos.browse(fiscal_position)
+        start_date, end_date = self._prepare_invoice_variable_dates()
+        domain = [
+            ('account_id', '=', self.analytic_account_id.id),
+            ('date', '>=', start_date),
+            ('date', '<=', end_date),
+            ('amount', '!=', 0.0)
+        ]
+        analytic_lines = Analytic.search(domain)
+        inv_lines = {}
+        for line in analytic_lines:
+            key = (line.product_id, line.product_uom_id)
+            inv_lines.setdefault(
+                key,
+                {'analytic_account_id': line.account_id.id,
+                 'product_id': line.product_id.id,
+                 'name': self._prepare_invoice_variable_name(line),
+                 'uom_id': line.product_uom_id.id,
+                 'price_unit': 0,
+                 })
+            inv_line = inv_lines[key]
+            inv_line['price_unit'] += line.amount
+
+        for key, value in inv_lines:
+            new_line = Analytic.new(value)
+            res.append(
+                [(0, 0, self._prepare_invoice_line(new_line, fiscal_position))]
+        return res

--- a/sale_subscription_invoice_variable/models/sale_subscription.py
+++ b/sale_subscription_invoice_variable/models/sale_subscription.py
@@ -70,7 +70,16 @@ class SaleSubscription(models.Model):
             )
         return res
 
-    def increment_period(self):
-        for subs in self:
-            subs.recurring_last_date = subs.recurring_next_date
-        super().increment_period()
+    def _prepare_invoice(self):
+        """
+        Set the last invoice date.
+
+        Done when an recurring invoice is prepared.
+        The _prepare_invoice() method is not called
+        by the line prorating features, and so doesn't
+        trigger setting this date.
+        """
+        invoicing_date = self.recurring_next_date
+        values = super()._prepare_invoice()
+        self.recurring_last_date = invoicing_date
+        return values

--- a/sale_subscription_invoice_variable/tests/__init__.py
+++ b/sale_subscription_invoice_variable/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_subscription_invoice

--- a/sale_subscription_invoice_variable/tests/test_subscription_invoice.py
+++ b/sale_subscription_invoice_variable/tests/test_subscription_invoice.py
@@ -8,7 +8,6 @@ class TestInvoice(TestSubscriptionCommon):
     def setUp(self, *args, **kwargs):
         super(TestInvoice, self).setUp(*args, **args)
 
-        import pudb; pu.db
         Product = self.env['product.product']
         self.prod_toilet_paper = Product.create({'name': 'Toilet Paper'})
         self.prod_hand_soap = Product.create({'name': 'Hand Soap'})

--- a/sale_subscription_invoice_variable/tests/test_subscription_invoice.py
+++ b/sale_subscription_invoice_variable/tests/test_subscription_invoice.py
@@ -1,0 +1,83 @@
+import datetime
+from odoo.addons.sale_subscription.tests.common_sale_subscription \
+    import TestSubscriptionCommon
+
+
+class TestInvoice(TestSubscriptionCommon):
+
+    def setUp(self, *args, **kwargs):
+        super(TestInvoice, self).setUp(*args, **args)
+
+        import pudb; pu.db
+        Product = self.env['product.product']
+        self.prod_toilet_paper = Product.create({'name': 'Toilet Paper'})
+        self.prod_hand_soap = Product.create({'name': 'Hand Soap'})
+
+        AnalyticLine = self.env['account.analytic.line']
+        today = datetime.date.today()
+        days = datetime.timedelta(days=1)
+
+        # Line 0 is before billing period
+        self.line_0 = AnalyticLine.create({
+            'name': 'Line 0',
+            'date': today - days * 1,
+            'account_id': self.account_1,
+            'product_id': self.prod_toilet_paper,
+            'amount': 25.0,
+        })
+        self.line_1 = AnalyticLine.create({
+            'name': 'Line 1',
+            'date': today,
+            'account_id': self.account_1,
+            'product_id': self.prod_toilet_paper,
+            'amount': 30.0,
+        })
+        self.line_2 = AnalyticLine.create({
+            'name': 'Line 2',
+            'date': today + days * 2,
+            'account_id': self.account_1,
+            'product_id': self.prod_hand_soap,
+            'amount': 40.0,
+        })
+        self.line_3 = AnalyticLine.create({
+            'name': 'Line 3',
+            'date': today + days * 3,
+            'account_id': self.account_1,
+            'product_id': self.prod_hand_soap,
+            'amount': 50.0,
+        })
+        # Line 4 is after billing period
+        self.line_4 = AnalyticLine.create({
+            'name': 'Line 4',
+            'date': today + days * 400,
+            'account_id': self.account_1,
+            'product_id': self.prod_hand_soap,
+            'amount': 60.0,
+        })
+
+    def test_variable(self):
+        # On Sale Order, set the Analytic Account and Confirm
+        self.sale_order.analytic_account_id = self.account_1
+        self.sale_order.action_confirm()
+
+        subscription = self.sale_order_line[0].subscription_id
+        subscription.recurring_invoice()
+
+        InvLines = self.env['accoutn.invoice.line']
+        inv_lines = InvLines.search(
+            [('product_id', '=', self.prod_toilet_paper)])
+        self.AssertEqual(
+            sum(x.price_subtotal for x in inv_lines),
+            30.0,
+            'Invoice Line 1, inside billing period')
+
+        inv_lines = InvLines.search(
+            [('product_id', '=', self.prod_hand_soap)])
+        self.AssertEqual(
+            sum(x.price_subtotal for x in inv_lines),
+            90.0,
+            'Invoice Line 2 and 3, inside billing period')
+        self.AssertEqual(
+            len(inv_lines),
+            1,
+            'Same product lines (2 and 3) should be in a single invoice line')

--- a/sale_subscription_invoice_variable/views/sale_subscription_views.xml
+++ b/sale_subscription_invoice_variable/views/sale_subscription_views.xml
@@ -1,0 +1,18 @@
+<odoo>
+
+    <!-- Copyright (C) 2019 Open Source Integrators
+         License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
+
+    <record id="sale_subscription_view_form_last_date" model="ir.ui.view">
+        <field name="name">sale.subscription.form add last date</field>
+        <field name="model">sale.subscription</field>
+        <field name="inherit_id"
+               ref="sale_subscription.sale_subscription_view_form"/>
+        <field name="arch" type="xml">
+            <field name="recurring_rule_boundary" position="after">
+                <field name="recurring_last_date"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Subscription Variable Invoicing
===============================

Include variable consumed amount in recurring bills.

The Subscription must have an Analytic Account, and
the additional consumptions should be recorded as Analytic Lines.

When the recurring invoice is being generated,
we look for the amounts in Analytic Lines
matching the Analytic Account and the dates of the invoicing period.

These will be added to the generated invoice.