### PR TITLE
[FIX] fieldservice_helpdesk_stock: Ticket Set To False on SR's

### DIFF
--- a/fieldservice_helpdesk_stock/models/stock_request_order.py
+++ b/fieldservice_helpdesk_stock/models/stock_request_order.py
@@ -57,6 +57,8 @@ class StockRequestOrder(models.Model):
                 line.fsm_order_id = self.fsm_order_id.id
                 line.helpdesk_ticket_id = \
                     self.fsm_order_id.ticket_id.id or False
+                if not line.helpdesk_ticket_id:
+                    line.helpdesk_ticket_id = self.helpdesk_ticket_id
 
     @api.multi
     def write(self, vals):


### PR DESCRIPTION
When we call the change_childs() we are setting the ticket based on the FSO, however if there is no FSO, then we should use the helpdesk_ticket_id on the actual SRO.