### PR TITLE
[IMP] helpdesk_stock: Hide route_id on stock requests

### DIFF
--- a/helpdesk_stock/views/helpdesk_views.xml
+++ b/helpdesk_stock/views/helpdesk_views.xml
@@ -62,7 +62,7 @@
                             <field name="product_uom_qty"/>
                             <field name="qty_in_progress"/>
                             <field name="qty_done"/>
-                            <field name="expected_date" invisible="1"/>
+                            <field name="expected_date"/>
                             <field name="picking_policy" invisible="1"/>
                             <field name="warehouse_id" invisible="1"/>
                             <field name="location_id" invisible="1"/>

--- a/helpdesk_stock/views/helpdesk_views.xml
+++ b/helpdesk_stock/views/helpdesk_views.xml
@@ -56,7 +56,8 @@
                             <field name="direction" required="1"/>
                             <field name="route_id"
                                    options="{'no_create': True}"
-                                   groups="stock.group_stock_multi_locations"/>
+                                   groups="stock.group_stock_multi_locations"
+                                   invisible="1"/>
                             <field name="route_ids" invisible="1"/>
                             <field name="product_uom_qty"/>
                             <field name="qty_in_progress"/>


### PR DESCRIPTION
Hide route_id on stock_request_ids in the Helpdesk module for consistency between FSOs and Tickets