### PR TITLE
[FIX] helpdesk_fieldservice: Set Context from Python not XML

### DIFF
--- a/helpdesk_fieldservice/models/fsm_location.py
+++ b/helpdesk_fieldservice/models/fsm_location.py
@@ -33,5 +33,6 @@ class FSMLocation(models.Model):
                 action['res_id'] = ticket_ids.ids[0]
             else:
                 action['domain'] = [('id', 'in', ticket_ids.ids)]
-                action['context'].update({'search_default_is_open': 1})
+                action['context'].update({'search_default_is_open': 1,
+                                          'default_fsm_location_id': self.id})
             return action

--- a/helpdesk_fieldservice/views/fsm_location_views.xml
+++ b/helpdesk_fieldservice/views/fsm_location_views.xml
@@ -25,8 +25,7 @@
                 <button name="action_view_ticket"
                         type="object"
                         class="oe_stat_button"
-                        icon="fa-pencil-square-o"
-                        context="{'default_fsm_location_id': active_id}">
+                        icon="fa-pencil-square-o">
                     <field name="ticket_count"
                            widget="statinfo"
                            string="Tickets"/>


### PR DESCRIPTION
When we go through multiple Smart Buttons it looks like the active_id stays set as the original record from the first Smart Button clicked. So, instead of relying on that, we set the default fields in the method behind the Smart Button