### PR TITLE
[IMP] helpdesk_stock: Stock request workflow adjustment

### DIFF
--- a/fieldservice_helpdesk_stock/models/stock_request_order.py
+++ b/fieldservice_helpdesk_stock/models/stock_request_order.py
@@ -24,7 +24,8 @@ class StockRequestOrder(models.Model):
                          ticket.fsm_location_id.id or False})
         return super().create(vals)
 
-    @api.onchange('direction', 'fsm_order_id', 'helpdesk_ticket_id')
+    @api.onchange('warehouse_id', 'direction', 'fsm_order_id',
+                  'helpdesk_ticket_id')
     def _onchange_location_id(self):
         super()._onchange_location_id()
         # FSM Order takes priority over Helpdesk Ticket

--- a/helpdesk_stock/models/stock_request_order.py
+++ b/helpdesk_stock/models/stock_request_order.py
@@ -11,7 +11,7 @@ class StockRequestOrder(models.Model):
                                          ondelete='cascade', index=True,
                                          copy=False)
 
-    @api.onchange('direction', 'helpdesk_ticket_id')
+    @api.onchange('warehouse_id', 'direction', 'helpdesk_ticket_id')
     def _onchange_location_id(self):
         super()._onchange_location_id()
         if self.helpdesk_ticket_id:


### PR DESCRIPTION
Same workflow we use in Fieldservice_stock. See this PR: https://github.com/OCA/field-service/pull/549

Edit: In order to maintain consistency with PR: https://github.com/OCA/stock-logistics-warehouse/pull/874 I have changed the header for the onchange methods in helpdesk_stock and fieldservice_helpdesk_stock