### PR TITLE
[IMP] helpdesk_delivery: Set Carrier on Pickings

### DIFF
--- a/helpdesk_delivery/models/__init__.py
+++ b/helpdesk_delivery/models/__init__.py
@@ -4,4 +4,6 @@
 from . import (
     helpdesk_ticket,
     stock_request,
+    stock_move,
+    stock_rule
 )

--- a/helpdesk_delivery/models/stock_move.py
+++ b/helpdesk_delivery/models/stock_move.py
@@ -1,0 +1,17 @@
+# Copyright (C) 2020 Open Source Integrators
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    helpdesk_ticket_id = fields.\
+        Many2one('helpdesk.ticket', string="Helpdesk Ticket")
+
+    def _get_new_picking_values(self):
+        vals = super(StockMove, self)._get_new_picking_values()
+        if not vals.get('carrier_id', False):
+            vals['carrier_id'] = self.helpdesk_ticket_id.carrier_id.id
+        return vals

--- a/helpdesk_delivery/models/stock_request.py
+++ b/helpdesk_delivery/models/stock_request.py
@@ -11,8 +11,18 @@ class StockRequest(models.Model):
 
     def _prepare_procurement_values(self, group_id=False):
         res = super()._prepare_procurement_values(group_id=group_id)
-        if res.get('carrier_id', False):
+        if not res.get('carrier_id', False):
             res.update({
                 'carrier_id': self.helpdesk_ticket_id.carrier_id.id or False,
             })
         return res
+
+    def _prepare_procurement_group_values(self):
+        if self.helpdesk_ticket_id:
+            order = self.env['helpdesk.ticket'].\
+                browse(self.helpdesk_ticket_id.id)
+            return {'name': order.name,
+                    'helpdesk_ticket_id': order.id,
+                    'move_type': 'direct'}
+        else:
+            return {}

--- a/helpdesk_delivery/models/stock_rule.py
+++ b/helpdesk_delivery/models/stock_rule.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2020, Open Source Integrators
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import models
+
+
+class StockRule(models.Model):
+    _inherit = 'stock.rule'
+
+    def _get_stock_move_values(self, product_id, product_qty, product_uom,
+                               location_id, name, origin, values, group_id):
+        vals = super()._get_stock_move_values(
+            product_id, product_qty, product_uom, location_id, name, origin,
+            values, group_id)
+        vals.update({'helpdesk_ticket_id': values.get('helpdesk_ticket_id')})
+        return vals

--- a/helpdesk_delivery/models/stock_rule.py
+++ b/helpdesk_delivery/models/stock_rule.py
@@ -1,6 +1,5 @@
-# Copyright (C) 2020, Open Source Integrators
+# Copyright (C) 2020 Open Source Integrators
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
-
 from odoo import models
 
 


### PR DESCRIPTION
This PR resolves ticket #1853 Medium: Stock Requests - Multiple issues with missing analytic accounts context. All items related to carrier_id I kept here in helpdesk_delivery. One concern I have is helpdesk_stock and fieldservice_stock are very different and keeping functionality the same from both sides appears to be tricky.