### PR TITLE
[FIX] osi_analytic_segments_purchase_subscription (Create Invoice Error)

### DIFF
--- a/osi_analytic_segments_purchase_subscription/models/purchase_subscription.py
+++ b/osi_analytic_segments_purchase_subscription/models/purchase_subscription.py
@@ -24,7 +24,7 @@ class PurchaseSubscription(models.Model):
         res = super()._prepare_invoice_line(line, fiscal_position)
         res.update({
             'analytic_segment_one_id':
-                self.order_id.analytic_segment_one_id.id,
+                line.analytic_segment_one_id.id,
             'analytic_segment_two_id':
-                self.order_id.analytic_segment_two_id.id})
+                line.analytic_segment_two_id.id})
         return res


### PR DESCRIPTION
This fixes an error that occurs when you try to create an invoice from a purchase subscription.
  File "/opt/odoo/v12/src/osi-addons/osi_analytic_segments_purchase_subscription/models/purchase_subscription.py", line 27, in _prepare_invoice_line
    self.order_id.analytic_segment_one_id.id,
AttributeError: 'purchase.subscription' object has no attribute 'order_id'