### PR TITLE
[IMP] fieldservice_googlemaps_address_autocompletion: Address Autocomplete on Name and Street

### DIFF
--- a/fieldservice_googlemaps_address_autocompletion/views/fsm_location.xml
+++ b/fieldservice_googlemaps_address_autocompletion/views/fsm_location.xml
@@ -7,8 +7,15 @@
         <field name="model">fsm.location</field>
         <field name='inherit_id' ref='fieldservice.fsm_location_form_view'/>
         <field name="arch" type="xml">
-            <field name='street' position='attributes'>
+            <field name='name' position='attributes'>
                 <attribute name='widget'>gplaces_autocomplete</attribute>
+                <attribute name='options'>
+                    {'lat':'partner_latitude','lng':'partner_longitude'}
+                </attribute>
+            </field>
+            <field name="street"
+                   position='attributes'>
+                <attribute name='widget'>gplaces_address_autocomplete</attribute>
                 <attribute name='options'>
                     {'lat':'partner_latitude','lng':'partner_longitude'}
                 </attribute>

--- a/fieldservice_googlemaps_address_autocompletion/views/res_partner.xml
+++ b/fieldservice_googlemaps_address_autocompletion/views/res_partner.xml
@@ -6,13 +6,19 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//sheet/group//field[@name='street']"
-                   position='attributes'>
+            <field name="name" position='attributes'>
                 <attribute name='widget'>gplaces_autocomplete</attribute>
                 <attribute name='options'>
                     {'lat':'partner_latitude','lng':'partner_longitude'}
                 </attribute>
-            </xpath>
+            </field>
+            <field name="street"
+                   position='attributes'>
+                <attribute name='widget'>gplaces_address_autocomplete</attribute>
+                <attribute name='options'>
+                    {'lat':'partner_latitude','lng':'partner_longitude'}
+                </attribute>
+            </field>
         </field>
     </record>
 


### PR DESCRIPTION
Apply the Name/Address autocomplete on 'name' and only apply Address Search on 'street' for both res_partner and fsm_location records.

The gplaces_address_autocomplete widget will only fill out the address fields and only searches on Addresses in Google but will not overwrite what is in the name field.

The gplaces_autocomplete widget searches on Establishments and Addresses in Google and will populate the address fields.