### PR TITLE
[FIX] helpdesk_timesheet_fieldservice (cannot be located in parent view)

### DIFF
--- a/helpdesk_timesheet_fieldservice/__manifest__.py
+++ b/helpdesk_timesheet_fieldservice/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Helpdesk Timesheet - Field Service',
     'summary': 'Create FSM Orders and Timesheet from Helpdesk Ticket',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.1.0',
     'license': 'LGPL-3',
     'author': 'Open Source Integrators',
     'category': 'Helpdesk',

--- a/helpdesk_timesheet_fieldservice/views/helpdesk_ticket.xml
+++ b/helpdesk_timesheet_fieldservice/views/helpdesk_ticket.xml
@@ -9,7 +9,7 @@
         <field name="inherit_id"
                ref="helpdesk_fieldservice.helpdesk_ticket_view_service_request_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//notebook/page/notebook" position="attributes">
+            <xpath expr="//notebook/page/field[@name='description']" position="attributes">
                 <attribute name="placeholder">Description of the ticket...</attribute>
             </xpath>
         </field>


### PR DESCRIPTION
This PR fixes the following view error that I noticed while installing this on a test instance:

ValueError: Element '<xpath expr="//notebook/page/notebook">' cannot be located in parent view
Error context:
View `helpdesk.ticket.fieldservice.form`
[view_id: 3651, xml_id: n/a, model: helpdesk.ticket, parent_id: 2284]