### PR TITLE
[IMP] connector_voicent_helpdesk_ticket: Do Not Repeat Job on Same Day

### DIFF
--- a/connector_voicent_helpdesk_ticket/models/__init__.py
+++ b/connector_voicent_helpdesk_ticket/models/__init__.py
@@ -4,3 +4,4 @@
 
 from . import backend_voicent_call_line
 from . import helpdesk_ticket
+from . import queue_job

--- a/connector_voicent_helpdesk_ticket/models/queue_job.py
+++ b/connector_voicent_helpdesk_ticket/models/queue_job.py
@@ -1,0 +1,24 @@
+# Copyright 2020 Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import api, models
+import time
+
+
+class QueueJob(models.Model):
+    _inherit = 'queue.job'
+
+    @api.model
+    def create(self, vals):
+        found = False
+        if vals.get('model_name') == 'helpdesk.ticket' and vals.get('name') == 'helpdesk.ticket.voicent_start_campaign':
+            record_ids = vals.get('record_ids')
+            job_ids = self.env['queue.job'].\
+                search([('model_name', '=', 'helpdesk.ticket'),
+                        ('name', '=', 'helpdesk.ticket.voicent_start_campaign'),
+                        ('date_created', '>', time.strftime('%Y-%m-%d 00:00:00'))])
+            for job_id in job_ids:
+                if record_ids == job_id.record_ids:
+                    found = True
+        if not found:
+            return super().create(vals)

--- a/connector_voicent_helpdesk_ticket/models/queue_job.py
+++ b/connector_voicent_helpdesk_ticket/models/queue_job.py
@@ -3,6 +3,7 @@
 
 from odoo import api, models
 import time
+from datetime import datetime
 
 
 class QueueJob(models.Model):
@@ -20,5 +21,8 @@ class QueueJob(models.Model):
             for job_id in job_ids:
                 if record_ids == job_id.record_ids:
                     found = True
-        if not found:
-            return super().create(vals)
+        if found:
+            eta = vals.get('eta')
+            eta = eta + datetime.timedelta(days=1)
+            vals.update({'eta': eta})
+        return super().create(vals)

--- a/connector_voicent_helpdesk_ticket/models/queue_job.py
+++ b/connector_voicent_helpdesk_ticket/models/queue_job.py
@@ -3,7 +3,7 @@
 
 from odoo import api, models
 import time
-from datetime import datetime
+from datetime import timedelta
 
 
 class QueueJob(models.Model):
@@ -23,6 +23,6 @@ class QueueJob(models.Model):
                     found = True
         if found:
             eta = vals.get('eta')
-            eta = eta + datetime.timedelta(days=1)
+            eta = eta + timedelta(days=1)
             vals.update({'eta': eta})
         return super().create(vals)


### PR DESCRIPTION
If we create a voicent_start_campaign job from a helpdesk ticket, and that job is moved to 'done', do not create a second job on the same day (ex: if the ticket is moved back a stage, and then back into the stage that generates a job). 

To do this, we check the job being created, ensure that it is from a helpdesk.ticket and it is a voicent_start_campaign. If it is, get all other jobs from that day that are also helpdesk.ticket.voicent_start_campaign, and see if the record_ids match. If so, do not create another job, if they are not the same, then continue creating the job.