### PR TITLE
[FIX] helpdesk_fieldservice (Error if user doesn't have helpdesk access)

### DIFF
--- a/helpdesk_fieldservice/views/res_partner.xml
+++ b/helpdesk_fieldservice/views/res_partner.xml
@@ -3,6 +3,7 @@
     <record id="res_partner_form_ticket_context" model="ir.ui.view">
         <field name="name">res.partner.form.ticket.context</field>
         <field name="model">res.partner</field>
+        <field name="groups_id" eval="[(4, ref('helpdesk.group_helpdesk_user'))]"/>
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="arch" type="xml">
             <button name="action_open_helpdesk_ticket" position="attributes">


### PR DESCRIPTION
This fixes an error if user doesn't have helpdesk access, when they try to open a contact they get the following error:
File "/opt/odoo/v12/env/lib/python3.6/site-packages/odoo-12.0-py3.6.egg/odoo/addons/base/models/ir_ui_view.py", line 710, in apply_inheritance_specs
    self.raise_view_error(_("Element '%s' cannot be located in parent view") % tag, inherit_id)
  File "/opt/odoo/v12/env/lib/python3.6/site-packages/odoo-12.0-py3.6.egg/odoo/addons/base/models/ir_ui_view.py", line 548, in raise_view_error
    raise ValueError(message)
ValueError: Element '<button name="action_open_helpdesk_ticket">' cannot be located in parent view

Error context:
View `res.partner.form.ticket.context`
[view_id: 3257, xml_id: helpdesk_fieldservice.res_partner_form_ticket_context, model: res.partner, parent_id: 113]