### PR TITLE
[FIX] helpdesk_fieldservice missing dependency

### DIFF
--- a/helpdesk_fieldservice/__manifest__.py
+++ b/helpdesk_fieldservice/__manifest__.py
@@ -11,6 +11,7 @@
     'depends': [
         'helpdesk',
         'fieldservice',
+        'helpdesk_resolution',
     ],
     'data': [
         'security/ir.model.access.csv',


### PR DESCRIPTION
'resolution' field introduced in helpdesk_resolution module. Ref: https://github.com/ursais/osi-addons/blob/12.0/helpdesk_resolution/models/helpdesk_ticket.py

We have used that field in close ticket event. Ref: https://github.com/ursais/osi-addons/blob/12.0/helpdesk_fieldservice/wizard/fsm_order_close_wizard.py#L20