### PR TITLE
[12.0][IMP] Exposed fsm_quantity field and added conditional coloring

### DIFF
--- a/fieldservice_mobile/__manifest__.py
+++ b/fieldservice_mobile/__manifest__.py
@@ -13,6 +13,7 @@
     'website': 'https://github.com/ursais/osi-addons',
     'depends': [
         'fieldservice_stage_server_action',
+        'artisent',
     ],
     'data': [
         'security/ir.model.access.csv',

--- a/fieldservice_mobile/__manifest__.py
+++ b/fieldservice_mobile/__manifest__.py
@@ -13,7 +13,6 @@
     'website': 'https://github.com/ursais/osi-addons',
     'depends': [
         'fieldservice_stage_server_action',
-        'artisent',
     ],
     'data': [
         'security/ir.model.access.csv',

--- a/fieldservice_mobile/models/__init__.py
+++ b/fieldservice_mobile/models/__init__.py
@@ -4,3 +4,4 @@ from . import res_config_settings
 from . import fsm_stage
 from . import fsm_order
 from . import fsm_stage_history
+from . import sale_order_line

--- a/fieldservice_mobile/models/sale_order_line.py
+++ b/fieldservice_mobile/models/sale_order_line.py
@@ -1,0 +1,11 @@
+# Copyright (C) 2020 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+from odoo.addons import decimal_precision as dp
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    fsm_quantity = fields.Float(string="FSM Quantity", digits=dp.get_precision("Product Unit of Measure"),)

--- a/fieldservice_mobile/views/fsm_order_view.xml
+++ b/fieldservice_mobile/views/fsm_order_view.xml
@@ -28,4 +28,18 @@
         </field>
     </record>
 
+    <record id="fsm_order_artisent_changes_inherit model" model="ir.ui.view">
+        <field name="name">fsm.order.artisent.changes.inherit</field>
+        <field name="model">fsm.order</field>
+        <field name="inherit_id" ref="artisent.fsm_order_artisent_changes"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='sale_order_line_ids']/tree/field[@name='product_uom_qty']" position="after">
+                <field name="fsm_quantity"/>
+            </xpath>
+            <xpath expr="//field[@name='sale_order_line_ids']/tree" position="attributes">
+                <attribute name="decoration-danger">fsm_quantity != product_uom_qty</attribute>
+            </xpath>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
Added fsm_quantity field at Sale Order Line Level on Field Service Order and added conditional coloring( red) on Sale Order Line to signify that there is a discrepancy between the Ordered QTY vs the fsm_quantity. 

ART-PH2-31-00-2102-001232 -Expose FSM_Quantity field on FSO
https://pm.opensourceintegrators.com/web#id=14819&model=project.task&view_type=form&menu_id=176