### PR TITLE
[FIX] osi_fifo_serialized_fix: wrong svl sign

### DIFF
--- a/osi_fifo_serialized_fix/models/stock_move.py
+++ b/osi_fifo_serialized_fix/models/stock_move.py
@@ -30,7 +30,7 @@ class StockMove(models.Model):
                                                    line_id.lot_id.id)
                 ji_ids = self.env['account.move.line'].\
                     search([('name', 'ilike', move.picking_id.name),
-                            ('name', 'ilike', move.product_id.name)])
+                            ('name', '=ilike', move.product_id.name)])
                 if ji_ids:
                     if len(svl_ids) > 1:
                         final_layers = []


### PR DESCRIPTION
Depends on https://github.com/ursais/osi-addons/pull/311


Fix Notes:

- when delivering several quantity of products with different lot numbers, the last Qty was used for all the valuation.
- when delivering a single quantity of serial or lot product, unit value was negative.lot_id also not set on svl.
- when delivering a multiple quantity of serial or lot product, total value was positive and journal entry of the invoices were also wrong

cc: @sodexisteam