### PR TITLE
[14.0][FIX] Fix the issue.

### DIFF
--- a/osi_helpdesk_stock/models/stock_request_order.py
+++ b/osi_helpdesk_stock/models/stock_request_order.py
@@ -44,8 +44,8 @@ class StockRequestOrder(models.Model):
         if self.helpdesk_ticket_id and not self.procurement_group_id:
             ticket = self.env["helpdesk.ticket"].browse(self.helpdesk_ticket_id.id)
             group = self.env["procurement.group"].search(
-                [("helpdesk_ticket_id", "=", ticket.id)]
-            )
+                [("helpdesk_ticket_id", "=", self.helpdesk_ticket_id.id)],
+                limit=1, order="id desc")
             if not group:
                 values = self._prepare_procurement_group_values()
                 group = self.env["procurement.group"].create(values)


### PR DESCRIPTION
    rec = super(StockRequestOrder, self).action_confirm()
  File "/opt/odoo/pavlov/pavlov-odoo/src/link-addons/osi_helpdesk_stock/models/stock_request_order.py", line 54, in action_confirm
    self.procurement_group_id = group.id
  File "/opt/odoo/pavlov/pavlov-odoo/odoo/odoo/fields.py", line 3815, in __get__
    raise ValueError("Expected singleton: %s" % record)
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/pavlov/pavlov-odoo/odoo/odoo/http.py", line 640, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/pavlov/pavlov-odoo/odoo/odoo/http.py", line 316, in _handle_exception
    raise exception.with_traceback(None) from new_cause
ValueError: Expected singleton: procurement.group(753, 370)