### PR TITLE
[FIX] osi_helpdesk_stock: Traceback procurement

### DIFF
--- a/osi_helpdesk_stock/models/stock_request_order.py
+++ b/osi_helpdesk_stock/models/stock_request_order.py
@@ -44,7 +44,7 @@ class StockRequestOrder(models.Model):
         if self.helpdesk_ticket_id and not self.procurement_group_id:
             ticket = self.env["helpdesk.ticket"].browse(self.helpdesk_ticket_id.id)
             group = self.env["procurement.group"].search(
-                [("helpdesk_ticket_id", "=", ticket.id)]
+                [("helpdesk_ticket_id", "=", ticket.id)], limit=1
             )
             if not group:
                 values = self._prepare_procurement_group_values()

--- a/osi_payment_method/models/purchase.py
+++ b/osi_payment_method/models/purchase.py
@@ -28,13 +28,11 @@ class PurchaseOrder(models.Model):
 class StockRule(models.Model):
     _inherit = "stock.rule"
 
-    def _prepare_purchase_order(
-        self, product_id, product_qty, product_uom, origin, values, partner
-    ):
-        res = super()._prepare_purchase_order(
-            product_id, product_qty, product_uom, origin, values, partner
-        )
-        if res and "payment_method" not in res:
+    def _prepare_purchase_order(self, company_id, origins, values):
+        res = super()._prepare_purchase_order(company_id, origins, values)
+        values = values[0]
+        partner = self.env["res.partner"].browse(values["partner_id"])
+        if partner and partner.payment_method:
             res.update(
                 {
                     "payment_method": partner.payment_method


### PR DESCRIPTION
We have another issue regarding SRO's if you confirm an SRO 90% of the time it will set its Procurement Group properly, however sometimes it does not and you get an error like this. I need you to investigate this error and find out why the SRO is not setting its Procurement Group properly