### PR TITLE
[FCN/16.0][FIX] Fix xls download and _get_valuation_data

### DIFF
--- a/osi_inventory_by_date/controllers/main.py
+++ b/osi_inventory_by_date/controllers/main.py
@@ -9,7 +9,7 @@ import base64
 from odoo import http
 from odoo.http import request
 
-from odoo.addons.web.controllers.main import content_disposition
+from odoo.http import content_disposition
 
 
 class Binary(http.Controller):

--- a/osi_inventory_by_date/report/inventory_valuation.py
+++ b/osi_inventory_by_date/report/inventory_valuation.py
@@ -172,17 +172,11 @@ class InventoryValuationCategory(models.AbstractModel):
                         concat('product.category,',pc.id) and
                         irp1.name='property_stock_valuation_account_id')
                     LEFT JOIN account_account acc1 on (acc1.id =
-                        substr(irp1.value_reference, strpos(
-                        irp1.value_reference, ',') + 1,
-                        length(irp1.value_reference) - strpos(
-                        irp1.value_reference,','))::int)
+                        substr(irp1.value_reference, strpos(irp1.value_reference, ',') + 1)::int)
                     LEFT JOIN ir_property irp2 on (irp2.res_id is null and
                         irp2.name='property_stock_valuation_account_id')
                     LEFT JOIN account_account acc2 on (acc2.id =
-                        substr(irp2.value_reference,strpos(
-                        irp2.value_reference, ',') + 1,
-                        length(irp2.value_reference) - strpos(
-                        irp2.value_reference,','))::int)
+                        substr(irp2.value_reference,strpos(irp2.value_reference, ',') + 1)::int)
                     LEFT JOIN ir_property cost on (cost.res_id =
                         concat('product.product,', pp.id) AND
                         cost.name='standard_price')
@@ -218,16 +212,11 @@ class InventoryValuationCategory(models.AbstractModel):
                         concat('product.category,', pc.id) AND
                         irp1.name='property_stock_valuation_account_id')
                     LEFT JOIN account_account acc1 ON (acc1.id = substr(
-                        irp1.value_reference, strpos(irp1.value_reference, ',
-                        ') + 1, length(irp1.value_reference) - strpos(
-                        irp1.value_reference, ','))::int)
+                        irp1.value_reference, strpos(irp1.value_reference, ',') + 1)::int)
                     LEFT JOIN ir_property irp2 on (irp2.res_id is null AND
                         irp2.name='property_stock_valuation_account_id')
                     LEFT JOIN account_account acc2 on (acc2.id =
-                        substr(irp2.value_reference, strpos(
-                        irp2.value_reference, ',') + 1, length(
-                        irp2.value_reference) - strpos(irp2.value_reference,',
-                        '))::int)
+                        substr(irp2.value_reference, strpos(irp2.value_reference, ',') + 1)::int)
                     LEFT JOIN ir_property cost on (cost.res_id =
                         concat('product.product,', pp.id) AND
                         cost.name='standard_price')
@@ -263,17 +252,11 @@ class InventoryValuationCategory(models.AbstractModel):
                         concat('product.category,',pc.id) AND
                         irp1.name='property_stock_valuation_account_id')
                     LEFT JOIN account_account acc1 on (acc1.id =
-                        substr(irp1.value_reference,strpos(
-                        irp1.value_reference, ',') + 1, length(
-                        irp1.value_reference) - strpos(irp1.value_reference, ',
-                        '))::int)
+                        substr(irp1.value_reference,strpos(irp1.value_reference, ',') + 1)::int)
                     LEFT JOIN ir_property irp2 on (irp2.res_id is null AND
                         irp2.name='property_stock_valuation_account_id')
                     LEFT JOIN account_account acc2 on (acc2.id =
-                        substr(irp2.value_reference, strpos(
-                        irp2.value_reference, ',') + 1, length(
-                        irp2.value_reference) - strpos(irp2.value_reference,',
-                        '))::int)
+                        substr(irp2.value_reference, strpos(irp2.value_reference, ',') + 1)::int)
                     LEFT JOIN ir_property cost on (cost.res_id =
                         concat('product.product,', pp.id) AND
                         cost.name='standard_price')
@@ -310,17 +293,11 @@ class InventoryValuationCategory(models.AbstractModel):
                         concat('product.category,',pc.id) AND
                         irp1.name='property_stock_valuation_account_id')
                     LEFT JOIN account_account acc1 on (acc1.id =
-                        substr(irp1.value_reference, strpos(
-                        irp1.value_reference, ',') + 1, length(
-                        irp1.value_reference) - strpos(irp1.value_reference,',
-                        '))::int)
+                        substr(irp1.value_reference, strpos(irp1.value_reference, ',') + 1)::int)
                     LEFT JOIN ir_property irp2 on (irp2.res_id is null AND
                         irp2.name='property_stock_valuation_account_id')
                     LEFT JOIN account_account acc2 on (acc2.id =
-                        substr(irp2.value_reference, strpos(
-                        irp2.value_reference, ',') + 1, length(
-                        irp2.value_reference) - strpos(irp2.value_reference,',
-                        '))::int)
+                        substr(irp2.value_reference, strpos(irp2.value_reference, ',') + 1)::int)
                     LEFT JOIN ir_property cost on (cost.res_id =
                         concat('product.product,', pp.id) AND
                         cost.name='standard_price')

--- a/osi_inventory_by_date/wizard/inventory_valuation.py
+++ b/osi_inventory_by_date/wizard/inventory_valuation.py
@@ -352,7 +352,7 @@ class InventoryValuationDateReport(models.TransientModel, InventoryValuationCate
         export_obj = self.env["inventory.valuation.success.box"]
         res_id = export_obj.create(
             {
-                "file": base64.encodestring(stream.getvalue()),
+                "file": base64.encodebytes(stream.getvalue()),
                 "fname": "Inventory Valuation by Location and Date Report.xls",
             }
         )


### PR DESCRIPTION
Ticket: https://pm.opensourceintegrators.com/web#id=31778&cids=1&menu_id=218&action=1093&model=helpdesk.ticket&view_type=form

Changes: 
1. **osi_inventory_by_date/controllers/main.py**: Resolved warning indicating that content_disposition had been moved and that the current import was incorrect.
2. **osi_inventory_by_date/report/inventory_valuation.py**: Fixed SQL query used to get data for the Inventory Valuation by Location and Date report. Subtrings were not being formed correctly and thus string values were attempting to be used as integers. this resolves the issue of the report bing generated with no rows of data.
3. **osi_inventory_by_date/wizard/inventory_valuation.py**: Fixed deprecated call to encodestring by replacing it with the correct call to encodebytes. This resolves the issue of the xls file download not working. 