### PR TITLE
[14.0][IMP] advance_check_void (Update Checks to Print on Dashboard)

### DIFF
--- a/advance_check_void/models/__init__.py
+++ b/advance_check_void/models/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2019 - TODAY, Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from . import account_journal
 from . import account_payment

--- a/advance_check_void/models/account_journal.py
+++ b/advance_check_void/models/account_journal.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2023 - TODAY, Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    def get_journal_dashboard_datas(self):
+        super().get_journal_dashboard_datas()
+        domain_checks_to_print = [
+            ("journal_id", "=", self.id),
+            ("payment_method_id.code", "=", "check_printing"),
+            ("state", "=", "posted"),
+            ("is_move_sent", "=", False),
+            ("payment_state", "!=", "reversed"),
+        ]
+        return dict(
+            super(AccountJournal, self).get_journal_dashboard_datas(),
+            num_checks_to_print=self.env["account.payment"].search_count(
+                domain_checks_to_print
+            ),
+        )

--- a/advance_check_void/views/account_payment_view.xml
+++ b/advance_check_void/views/account_payment_view.xml
@@ -151,4 +151,15 @@
             </form>
         </field>
     </record>
+
+    <record id="view_payment_check_void_search" model="ir.ui.view">
+            <field name="name">payment.check.void.search</field>
+            <field name="model">account.payment</field>
+            <field name="inherit_id" ref="account_check_printing.view_payment_check_printing_search"/>
+            <field name="arch" type="xml">
+                <xpath expr="//filter[@name='checks_to_send']" position="attributes">
+                    <attribute name="domain">[('payment_method_id.code', '=', 'check_printing'), ('state', '=', 'posted'), ('is_move_sent', '=', False), ("payment_state", "!=", "reversed")]</attribute>
+                </xpath>
+            </field>
+        </record>
 </odoo>


### PR DESCRIPTION
Updates domain on 'Check's to Print' dashboard to exclude reversed checks.
[Voided Check Backend status (#35283)](https://pm.opensourceintegrators.com/web#id=35283&menu_id=218&cids=1&action=1093&model=helpdesk.ticket&view_type=form)