### PR TITLE
[17.0][UPD] osi_partner_credit_limit: fix readonly attribute that had…

### DIFF
--- a/osi_partner_credit_limit/views/sale.xml
+++ b/osi_partner_credit_limit/views/sale.xml
@@ -29,13 +29,13 @@
             <field name='ship_hold' position="attributes">
                 <attribute
                     name="readonly"
-                >"state not in ('draft', 'sent', 'sale')"</attribute>
+                >state not in ('draft', 'sent', 'sale')</attribute>
                 <attribute
                     name="groups"
                 >osi_partner_credit_limit.group_credit_hold</attribute>
             </field>
             <field name='credit_override' position="attributes">
-                <attribute name="readonly">"state in ('cancel', 'done')"</attribute>
+                <attribute name="readonly">state in ('cancel', 'done')</attribute>
                 <attribute
                     name="groups"
                 >osi_partner_credit_limit.group_credit_hold</attribute>


### PR DESCRIPTION
… extra quotation marks in it