### PR TITLE
Revert Changes on ol_product_state/ol_job_cost_estimator

### DIFF
--- a/ol_job_cost_estimator_tier_validation/views/sale_estimate_views.xml
+++ b/ol_job_cost_estimator_tier_validation/views/sale_estimate_views.xml
@@ -53,8 +53,4 @@
         </field>
     </record>
 
-    <record id="job_cost_estimate_customer.action_estimate_job" model="ir.actions.act_window">
-        <field name="groups_id" eval="[(4, ref('product.group_sale_pricelist'))]" />
-    </record>
-
 </odoo>

--- a/ol_product_state/views/product_template_view.xml
+++ b/ol_product_state/views/product_template_view.xml
@@ -10,9 +10,7 @@
             </xpath>
             <field name="product_state_id" position="after">
                 <field name="has_product_state_change_group" invisible="1" />
-            </field>
-            <field name="product_state_id" position="attributes">
-                <attribute name="invisible">has_product_state_change_group</attribute>
+                <field name="product_state_id" readonly="1" widget="statusbar" invisible="has_product_state_change_group" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
Reverted changes for product state as it made the stages disappear and that function was working correctly before. Job cost changes were made directly in the paid module so these changes aren't needed.