### PR TITLE
ol_mrp_sale_price_rollup (Multiple Line Price Improvements)

### DIFF
--- a/job_cost_estimate_customer/models/sale_estimate_lines.py
+++ b/job_cost_estimate_customer/models/sale_estimate_lines.py
@@ -4,137 +4,91 @@ from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 import odoo.addons.decimal_precision as dp
 
+
 class SaleEstimatelineJob(models.Model):
     _name = "sale.estimate.line.job"
-    _description = 'Sale Estimate line Job'
-    
-    @api.depends('price_unit','product_uom_qty','discount')
+    _description = "Sale Estimate line Job"
+
+    @api.depends("price_unit", "product_uom_qty", "discount")
     def _compute_amount(self):
         for rec in self:
             if rec.discount:
-                disc_amount = (rec.price_unit * rec.product_uom_qty) * rec.discount / 100
-                rec.price_subtotal = (rec.price_unit * rec.product_uom_qty) - disc_amount
+                disc_amount = (
+                    (rec.price_unit * rec.product_uom_qty) * rec.discount / 100
+                )
+                rec.price_subtotal = (
+                    rec.price_unit * rec.product_uom_qty
+                ) - disc_amount
             else:
                 rec.price_subtotal = rec.price_unit * rec.product_uom_qty
-            
+
     estimate_id = fields.Many2one(
-        'sale.estimate.job',
-        string='Sale Estimate', 
+        "sale.estimate.job",
+        string="Sale Estimate",
     )
-    product_id = fields.Many2one(
-        'product.product',
-        string='Product',
-        required=True
-    )
+    product_id = fields.Many2one("product.product", string="Product", required=True)
     product_uom_qty = fields.Float(
-        string='Quantity', 
-        #digits=dp.get_precision('Product Unit of Measure'), 
-        required=True, 
+        string="Quantity",
+        # digits=dp.get_precision('Product Unit of Measure'),
+        required=True,
         default=1.0,
-        digits='Product Unit of Measure',
+        digits="Product Unit of Measure",
     )
     product_uom = fields.Many2one(
-        'uom.uom', #produtc.uom
-        string='Unit of Measure', 
-        required=True
+        "uom.uom", string="Unit of Measure", required=True  # produtc.uom
     )
     price_unit = fields.Float(
-        'Unit Price', 
-        required=True, 
-        #digits=dp.get_precision('Product Price'), 
+        "Unit Price",
+        required=True,
+        # digits=dp.get_precision('Product Price'),
         default=0.0,
-        digits='Product Price',
+        digits="Product Price",
     )
     price_subtotal = fields.Float(
-        compute='_compute_amount', 
-        string='Subtotal', 
+        compute="_compute_amount",
+        string="Subtotal",
         store=True,
-        digits='Product Price',
+        digits="Product Price",
     )
-    product_description = fields.Char(
-        string='Description'
-    )
+    product_description = fields.Char(string="Description")
     discount = fields.Float(
-        string='Discount (%)',
+        string="Discount (%)",
     )
-    company_id = fields.Many2one(related='estimate_id.company_id', string='Company', store=True, readonly=True)
-    tax_id = fields.Many2many('account.tax', string='Taxes', domain=['|', ('active', '=', False), ('active', '=', True)])
+    company_id = fields.Many2one(
+        related="estimate_id.company_id", string="Company", store=True, readonly=True
+    )
+    tax_id = fields.Many2many(
+        "account.tax",
+        string="Taxes",
+        domain=["|", ("active", "=", False), ("active", "=", True)],
+    )
 
     job_type = fields.Selection(
-        selection=[('material','Material'),
-                   ('labour','Labour'),
-                    ('overhead','Overhead')
-                ],
+        selection=[
+            ("material", "Material"),
+            ("labour", "Labour"),
+            ("overhead", "Overhead"),
+        ],
         string="Type",
         required=True,
     )
     analytic_id = fields.Many2one(
-        'account.analytic.account',
-        'Analytic Account',
+        "account.analytic.account",
+        "Analytic Account",
         # store=True,
     )
 
-    # @api.multi
-    # @api.onchange('product_id')
-    # def product_id_change(self):
-    #     if not self.product_id:
-    #         return {'domain': {'product_uom': []}}
-
-    #     vals = {}
-    #     domain = {'product_uom': [('category_id', '=', self.product_id.uom_id.category_id.id)]}
-    #     if not self.product_uom or (self.product_id.uom_id.id != self.product_uom.id):
-    #         vals['product_uom'] = self.product_id.uom_id
-    #         vals['product_uom_qty'] = 1.0
-
-    #     product = self.product_id.with_context(
-    #         lang=self.estimate_id.partner_id.lang,
-    #         partner=self.estimate_id.partner_id.id,
-    #         quantity=vals.get('product_uom_qty') or self.product_uom_qty,
-    #         date=self.estimate_id.estimate_date,
-    #         pricelist=self.estimate_id.pricelist_id.id,
-    #         uom=self.product_uom.id
-    #     )
-
-    #     name = product.name_get()[0][1]
-    #     if product.description_sale:
-    #         name += '\n' + product.description_sale
-    #     vals['product_description'] = name
-
-    #     self._compute_tax_id()
-
-    #     if self.estimate_id.pricelist_id and self.estimate_id.partner_id:
-    #         vals['price_unit'] = self.env['account.tax']._fix_tax_included_price(self._get_display_price(product), product.taxes_id, self.tax_id)
-    #     self.update(vals)
-
-    #     title = False
-    #     message = False
-    #     warning = {}
-    #     if product.sale_line_warn != 'no-message':
-    #         title = _("Warning for %s") % product.name
-    #         message = product.sale_line_warn_msg
-    #         warning['title'] = title
-    #         warning['message'] = message
-    #         if product.sale_line_warn == 'block':
-    #             self.product_id = False
-    #         return {'warning': warning}
-    #     return {'domain': domain}
-
-    # @api.multi
-    # def _compute_tax_id(self):
-    #     for line in self:
-    #         fpos = line.estimate_id.partner_id.property_account_position_id
-    #         # If company_id is set, always filter taxes by the company
-    #         taxes = line.product_id.taxes_id.filtered(lambda r: not line.company_id or r.company_id == line.company_id)
-    #         # line.tax_id = fpos.map_tax(taxes, line.product_id, line.estimate_id.partner_id) if fpos else taxes
-    #         line.tax_id = fpos.map_tax(taxes)#14 feb 2022
-
-    def _compute_tax_id(self): #14 feb 2022
+    def _compute_tax_id(self):  # 14 feb 2022
         for line in self:
             line = line.with_company(line.company_id)
             # fpos = self.env['account.fiscal.position'].get_fiscal_position(line.estimate_id.partner_id.id)
-            fpos = self.env['account.fiscal.position']._get_fiscal_position(line.estimate_id.partner_id)
+            fpos = self.env["account.fiscal.position"]._get_fiscal_position(
+                line.estimate_id.partner_id
+            )
             # If company_id is set, always filter taxes by the company
-            taxes = line.product_id.taxes_id.filtered(lambda r: not line.company_id or r.company_id == line.company_id)
+            taxes = line.product_id.taxes_id.filtered(
+                lambda r: not line.company_id or r.company_id == line.company_id
+            )
             line.tax_id = fpos.map_tax(taxes)
 
     def _get_custom_pricelist_item_id(self):
@@ -151,7 +105,7 @@ class SaleEstimatelineJob(models.Model):
 
             pricelist_item = pricelist_item_id
 
-            pricelist_rule = self.env['product.pricelist.item'].browse(pricelist_item)
+            pricelist_rule = self.env["product.pricelist.item"].browse(pricelist_item)
 
             order_date = line.estimate_id.estimate_date or fields.Date.today()
             product = line.product_id
@@ -160,18 +114,25 @@ class SaleEstimatelineJob(models.Model):
 
             price = pricelist_rule._compute_price(
                 # product, qty, uom, order_date, currency=self.currency_id)
-                product, qty, uom, order_date, currency=line.estimate_id.pricelist_id.currency_id)
+                product,
+                qty,
+                uom,
+                order_date,
+                currency=line.estimate_id.pricelist_id.currency_id,
+            )
         return price
 
     def _get_pricelist_price_before_discount(self):
         for line in self:
             pricelist_item_id = line.estimate_id.pricelist_id._get_product_rule(
-                        line.product_id,
-                        line.product_uom_qty or 1.0,
-                        uom=line.product_uom,
-                        date=line.estimate_id.estimate_date,
-                    )
-            pricelist_rule = self.env['product.pricelist.item'].browse(pricelist_item_id)
+                line.product_id,
+                line.product_uom_qty or 1.0,
+                uom=line.product_uom,
+                date=line.estimate_id.estimate_date,
+            )
+            pricelist_rule = self.env["product.pricelist.item"].browse(
+                pricelist_item_id
+            )
 
             order_date = line.estimate_id.estimate_date or fields.Date.today()
             product = line.product_id
@@ -180,13 +141,20 @@ class SaleEstimatelineJob(models.Model):
 
             if pricelist_rule:
                 pricelist_item = pricelist_rule
-                if pricelist_item.pricelist_id.discount_policy == 'without_discount':
+                if pricelist_item.pricelist_id.discount_policy == "without_discount":
                     # Find the lowest pricelist rule whose pricelist is configured
                     # to show the discount to the customer.
-                    while pricelist_item.base == 'pricelist' and pricelist_item.base_pricelist_id.discount_policy == 'without_discount':
+                    while (
+                        pricelist_item.base == "pricelist"
+                        and pricelist_item.base_pricelist_id.discount_policy
+                        == "without_discount"
+                    ):
                         rule_id = pricelist_item.base_pricelist_id._get_product_rule(
-                            product, qty, uom=uom, date=order_date)
-                        pricelist_item = self.env['product.pricelist.item'].browse(rule_id)
+                            product, qty, uom=uom, date=order_date
+                        )
+                        pricelist_item = self.env["product.pricelist.item"].browse(
+                            rule_id
+                        )
 
                 pricelist_rule = pricelist_item
 
@@ -199,70 +167,60 @@ class SaleEstimatelineJob(models.Model):
             )
 
         return price
-       
 
     def _get_display_price(self, product):
         # TO DO: move me in master/saas-16 on sale.order
 
         pricelist_price = self._get_custom_pricelist_item_id()
 
-        if self.estimate_id.pricelist_id.discount_policy == 'with_discount':
+        if self.estimate_id.pricelist_id.discount_policy == "with_discount":
             # return product.with_context(pricelist=self.estimate_id.pricelist_id.id,  uom=self.product_uom.id).price
             return pricelist_price
-        # product_context = dict(self.env.context, partner_id=self.estimate_id.partner_id.id, date=self.estimate_id.estimate_date, uom=self.product_uom.id)#
-
-        # final_price, rule_id = self.estimate_id.pricelist_id.with_context(product_context).get_product_price_rule(product or self.product_id, self.product_uom_qty or 1.0, self.estimate_id.partner_id)
-        # base_price, currency = self.with_context(product_context)._get_real_price_currency(product, rule_id, self.product_uom_qty, 
-        #     self.product_uom, self.estimate_id.pricelist_id.id)
-        # if currency != self.estimate_id.pricelist_id.currency_id: #
-        #     base_price = currency._convert(
-        #         base_price, self.estimate_id.pricelist_id.currency_id,
-        #         self.estimate_id.company_id or self.env.company, self.estimate_id.estimate_date or fields.Date.today()) #
 
         base_price = self._get_pricelist_price_before_discount()
 
         # return max(base_price, final_price)
         return max(base_price, pricelist_price)
 
-
-    @api.onchange('product_id')
+    @api.onchange("product_id")
     def product_id_change(self):
         if not self.product_id:
-            return {'domain': {'product_uom': []}}
+            return {"domain": {"product_uom": []}}
 
         vals = {}
-        domain = {'product_uom': [('category_id', '=', self.product_id.uom_id.category_id.id)]}
+        domain = {
+            "product_uom": [("category_id", "=", self.product_id.uom_id.category_id.id)]
+        }
         if not self.product_uom or (self.product_id.uom_id.id != self.product_uom.id):
-            vals['product_uom'] = self.product_id.uom_id
-            vals['product_uom_qty'] = 1.0
+            vals["product_uom"] = self.product_id.uom_id
+            vals["product_uom_qty"] = 1.0
 
         product = self.product_id.with_context(
             partner=self.estimate_id.partner_id.id,
-            quantity=vals.get('product_uom_qty') or self.product_uom_qty,
+            quantity=vals.get("product_uom_qty") or self.product_uom_qty,
             date=self.estimate_id.estimate_date,
             pricelist=self.estimate_id.pricelist_id.id,
-            uom=self.product_uom.id
+            uom=self.product_uom.id,
         )
 
         name = product.name_get()[0][1]
         if product.description_sale:
-            name += '\n' + product.description_sale
-        vals['product_description'] = name
+            name += "\n" + product.description_sale
+        vals["product_description"] = name
 
         self._compute_tax_id()
 
         if self.estimate_id.pricelist_id and self.estimate_id.partner_id:
-            vals['price_unit'] = product._get_tax_included_unit_price(
+            vals["price_unit"] = product._get_tax_included_unit_price(
                 self.company_id,
                 self.estimate_id.currency_id,
                 self.estimate_id.estimate_date,
-                'sale',
-                product_price_unit=self._get_display_price(product),
-                product_currency=self.estimate_id.currency_id
+                "sale",
+                product_price_unit=self._get_display_price(product)
+                or product.lst_price,
+                product_currency=self.estimate_id.currency_id,
             )
 
-        # if self.estimate_id.pricelist_id and self.estimate_id.partner_id:
-        #     vals['price_unit'] = self.env['account.tax']._fix_tax_included_price(self._get_display_price(product), product.taxes_id, self.tax_id)
         self.update(vals)
 
         title = False
@@ -270,47 +228,52 @@ class SaleEstimatelineJob(models.Model):
         warning = {}
 
         product = self.product_id
-        if product and product.sale_line_warn != 'no-message':
-            if product.sale_line_warn == 'block':
+        if product and product.sale_line_warn != "no-message":
+            if product.sale_line_warn == "block":
                 self.product_id = False
             return {
-                'warning': {
-                    'title': _("Warning for %s", product.name),
-                    'message': product.sale_line_warn_msg,
+                "warning": {
+                    "title": _("Warning for %s", product.name),
+                    "message": product.sale_line_warn_msg,
                 }
             }
 
     def _get_real_price_currency(self, product, rule_id, qty, uom, pricelist_id):
         """Retrieve the price before applying the pricelist
-            :param obj product: object of current product record
-            :parem float qty: total quentity of product
-            :param tuple price_and_rule: tuple(price, suitable_rule) coming from pricelist computation
-            :param obj uom: unit of measure of current order line
-            :param integer pricelist_id: pricelist id of sales order"""
-        PricelistItem = self.env['product.pricelist.item']
-        field_name = 'lst_price'
+        :param obj product: object of current product record
+        :parem float qty: total quentity of product
+        :param tuple price_and_rule: tuple(price, suitable_rule) coming from pricelist computation
+        :param obj uom: unit of measure of current order line
+        :param integer pricelist_id: pricelist id of sales order"""
+        PricelistItem = self.env["product.pricelist.item"]
+        field_name = "lst_price"
         currency_id = None
         product_currency = product.currency_id
         if rule_id:
             pricelist_item = PricelistItem.browse(rule_id)
-            # if pricelist_item.pricelist_id.discount_policy == 'without_discount':
-            #     while pricelist_item.base == 'pricelist' and pricelist_item.base_pricelist_id and pricelist_item.base_pricelist_id.discount_policy == 'without_discount':
-            #         _price, rule_id = pricelist_item.base_pricelist_id.with_context(uom=uom.id).get_product_price_rule(product, qty, self.estimate_id.partner_id)
-            #         pricelist_item = PricelistItem.browse(rule_id)
-            if pricelist_item.pricelist_id.discount_policy == 'without_discount':
+            if pricelist_item.pricelist_id.discount_policy == "without_discount":
                 # Find the lowest pricelist rule whose pricelist is configured
                 # to show the discount to the customer.
-                while pricelist_item.base == 'pricelist' and pricelist_item.base_pricelist_id.discount_policy == 'without_discount':
+                while (
+                    pricelist_item.base == "pricelist"
+                    and pricelist_item.base_pricelist_id.discount_policy
+                    == "without_discount"
+                ):
                     rule_id = pricelist_item.base_pricelist_id._get_product_rule(
-                        product, qty, uom=uom, date=order_date)
-                    pricelist_item = self.env['product.pricelist.item'].browse(rule_id)
+                        product, qty, uom=uom, date=order_date
+                    )
+                    pricelist_item = self.env["product.pricelist.item"].browse(rule_id)
 
-            if pricelist_item.base == 'standard_price':
-                field_name = 'standard_price'
+            if pricelist_item.base == "standard_price":
+                field_name = "standard_price"
                 product_currency = product.cost_currency_id
-            elif pricelist_item.base == 'pricelist' and pricelist_item.base_pricelist_id:
-                field_name = 'price'
-                product = product.with_context(pricelist=pricelist_item.base_pricelist_id.id)
+            elif (
+                pricelist_item.base == "pricelist" and pricelist_item.base_pricelist_id
+            ):
+                field_name = "price"
+                product = product.with_context(
+                    pricelist=pricelist_item.base_pricelist_id.id
+                )
                 product_currency = pricelist_item.base_pricelist_id.currency_id
             currency_id = pricelist_item.pricelist_id.currency_id
 
@@ -321,9 +284,14 @@ class SaleEstimatelineJob(models.Model):
             if currency_id.id == product_currency.id:
                 cur_factor = 1.0
             else:
-                cur_factor = currency_id._get_conversion_rate(product_currency, currency_id, self.company_id or self.env.company, self.estimate_id.estimate_date or fields.Date.today())
+                cur_factor = currency_id._get_conversion_rate(
+                    product_currency,
+                    currency_id,
+                    self.company_id or self.env.company,
+                    self.estimate_id.estimate_date or fields.Date.today(),
+                )
 
-        product_uom = self.env.context.get('uom') or product.uom_id.id
+        product_uom = self.env.context.get("uom") or product.uom_id.id
         if uom and uom.id != product_uom:
             # the unit price is in a different uom
             uom_factor = uom._compute_price(1.0, product.uom_id)
@@ -332,12 +300,18 @@ class SaleEstimatelineJob(models.Model):
 
         return product[field_name] * uom_factor * cur_factor, currency_id
 
-    @api.onchange('product_id', 'price_unit', 'product_uom', 'product_uom_qty', 'tax_id')
+    @api.onchange(
+        "product_id", "price_unit", "product_uom", "product_uom_qty", "tax_id"
+    )
     def _onchange_discount(self):
-        if not (self.product_id and self.product_uom and
-                self.estimate_id.partner_id and self.estimate_id.pricelist_id and
-                self.estimate_id.pricelist_id.discount_policy == 'without_discount' and
-                self.env.user.has_group('product.group_discount_per_so_line')):
+        if not (
+            self.product_id
+            and self.product_uom
+            and self.estimate_id.partner_id
+            and self.estimate_id.pricelist_id
+            and self.estimate_id.pricelist_id.discount_policy == "without_discount"
+            and self.env.user.has_group("product.group_discount_per_so_line")
+        ):
             return
 
         self.discount = 0.0
@@ -348,40 +322,41 @@ class SaleEstimatelineJob(models.Model):
             date=self.estimate_id.estimate_date,
             pricelist=self.estimate_id.pricelist_id.id,
             uom=self.product_uom.id,
-            fiscal_position=self.env.context.get('fiscal_position')
+            fiscal_position=self.env.context.get("fiscal_position"),
         )
 
-        product_context = dict(self.env.context, partner_id=self.estimate_id.partner_id.id, date=self.estimate_id.estimate_date, uom=self.product_uom.id)
+        product_context = dict(
+            self.env.context,
+            partner_id=self.estimate_id.partner_id.id,
+            date=self.estimate_id.estimate_date,
+            uom=self.product_uom.id,
+        )
 
         # price, rule_id = self.estimate_id.pricelist_id.with_context(product_context).get_product_price_rule(self.product_id, self.product_uom_qty or 1.0, self.estimate_id.partner_id)
-        price, rule_id = self.estimate_id.pricelist_id.with_context(product_context)._get_product_price_rule(self.product_id, self.product_uom_qty or 1.0)
-        new_list_price, currency = self.with_context(product_context)._get_real_price_currency(product, rule_id, self.product_uom_qty, self.product_uom, self.estimate_id.pricelist_id.id)
+        price, rule_id = self.estimate_id.pricelist_id.with_context(
+            product_context
+        )._get_product_price_rule(self.product_id, self.product_uom_qty or 1.0)
+        new_list_price, currency = self.with_context(
+            product_context
+        )._get_real_price_currency(
+            product,
+            rule_id,
+            self.product_uom_qty,
+            self.product_uom,
+            self.estimate_id.pricelist_id.id,
+        )
 
         if new_list_price != 0:
             if self.estimate_id.pricelist_id.currency_id != currency:
                 # we need new_list_price in the same currency as price, which is in the SO's pricelist's currency
                 new_list_price = currency._convert(
-                    new_list_price, self.estimate_id.pricelist_id.currency_id,
-                    self.estimate_id.company_id or self.env.company, self.estimate_id.estimate_date or fields.Date.today())
+                    new_list_price,
+                    self.estimate_id.pricelist_id.currency_id,
+                    self.estimate_id.company_id or self.env.company,
+                    self.estimate_id.estimate_date or fields.Date.today(),
+                )
             discount = (new_list_price - price) / new_list_price * 100
-            if (discount > 0 and new_list_price > 0) or (discount < 0 and new_list_price < 0):
+            if (discount > 0 and new_list_price > 0) or (
+                discount < 0 and new_list_price < 0
+            ):
                 self.discount = discount
-
-        # if product.sale_line_warn != 'no-message':
-        #     title = _("Warning for %s") % product.name
-        #     message = product.sale_line_warn_msg
-        #     warning['title'] = title
-        #     warning['message'] = message
-        #     if product.sale_line_warn == 'block':
-        #         self.product_id = False
-        #     return {'warning': warning}
-        # return {'domain': domain}
-
-    # @api.multi
-    # def _get_display_price(self, product):
-    #     if self.estimate_id.pricelist_id.discount_policy == 'without_discount':
-    #         from_currency = self.estimate_id.company_id.currency_id
-    #         return from_currency.compute(product.lst_price, self.estimate_id.pricelist_id.currency_id)
-    #     return product.with_context(pricelist=self.estimate_id.pricelist_id.id).price
-        
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/ol_mrp_sale_price_rollup/__init__.py
+++ b/ol_mrp_sale_price_rollup/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import report
+from . import wizard

--- a/ol_mrp_sale_price_rollup/__manifest__.py
+++ b/ol_mrp_sale_price_rollup/__manifest__.py
@@ -14,11 +14,13 @@
     # any module necessary for this one to work correctly
     "depends": [
         "ol_base",
+        "sale_blanket_order",
         "sale",
         "mrp",
         "mrp_account",
         "product_configurator_mrp",
         "product_configurator_sale",
+        "product_configurator_sale_blanket_order",
         "osi_mrp_bom_sequence",
     ],
     # always loaded

--- a/ol_mrp_sale_price_rollup/__manifest__.py
+++ b/ol_mrp_sale_price_rollup/__manifest__.py
@@ -18,6 +18,7 @@
         "mrp",
         "mrp_account",
         "product_configurator_mrp",
+        "product_configurator_sale",
         "osi_mrp_bom_sequence",
     ],
     # always loaded

--- a/ol_mrp_sale_price_rollup/models/__init__.py
+++ b/ol_mrp_sale_price_rollup/models/__init__.py
@@ -1,3 +1,4 @@
+from . import blanket_orders
 from . import product_config
 from . import product_product
 from . import product_template

--- a/ol_mrp_sale_price_rollup/models/blanket_orders.py
+++ b/ol_mrp_sale_price_rollup/models/blanket_orders.py
@@ -1,0 +1,21 @@
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+from odoo.tools import float_is_zero
+
+
+class BlanketOrderLine(models.Model):
+    _inherit = "sale.blanket.order.line"
+
+    @api.onchange("product_id", "original_uom_qty")
+    def onchange_product(self):
+        super().onchange_product()
+        precision = self.env["decimal.precision"].precision_get(
+            "Product Unit of Measure"
+        )
+        if self.order_id.partner_id and float_is_zero(
+            self.price_unit, precision_digits=precision
+        ):
+            # Use the custom logic for price_unit assignment
+            self.price_unit = self._get_display_price() or self.product_id.lst_price

--- a/ol_mrp_sale_price_rollup/models/product_config.py
+++ b/ol_mrp_sale_price_rollup/models/product_config.py
@@ -1,5 +1,5 @@
 # Import Odoo libs
-from odoo import models
+from odoo import api, models
 
 
 class ProductConfigSession(models.Model):
@@ -15,3 +15,52 @@ class ProductConfigSession(models.Model):
         additional_total = variant._get_bom_sale_price()
         variant.lst_price = additional_total
         return variant
+
+    @api.depends(
+        "value_ids",
+        "product_id.lst_price",  # Change to variant lst_price
+        "product_tmpl_id.attribute_line_ids",
+        "product_tmpl_id.attribute_line_ids.value_ids",
+        "product_tmpl_id.attribute_line_ids.product_template_value_ids",
+        "product_tmpl_id.attribute_line_ids.product_template_value_ids.price_extra",
+    )
+    def _compute_cfg_price(self):
+        # Call super to preserve original functionality
+        super()._compute_cfg_price()
+
+        # Now extend the functionality to use variant price
+        for session in self:
+            if session.product_id:  # Using product variant instead of template
+                # Recalculate price based on variant's lst_price using your custom logic
+                price = session.with_company(session.company_id).get_cfg_price()
+                session.price = price
+
+    @api.model
+    def get_cfg_price(self, value_ids=[], custom_vals=None):
+        # Call the original method with super() to preserve its logic
+        super().get_cfg_price(value_ids, custom_vals)
+
+        # Now modify the logic to use the variant lst_price instead of the product template
+        product_variant = self.product_id  # Assuming this refers to the variant
+        value_ids = value_ids + self.value_ids.ids
+
+        # You can adjust any context or additional logic here if needed
+        if self.env.context.get("tobe_remove_attr", []):
+            value_ids = self.flatten_val_ids(value_ids)
+            value_ids = set(value_ids) - set(
+                self.env.context.get("tobe_remove_attr", [])
+            )
+            value_ids = list(value_ids)
+
+        value_ids = self.flatten_val_ids(value_ids)
+
+        # Fetch extra price based on attribute values
+        attr_val_obj = self.env["product.attribute.value"]
+        av_ids = attr_val_obj.browse(value_ids)
+        extra_prices = attr_val_obj.get_attribute_value_extra_prices(
+            product_tmpl_id=product_variant.product_tmpl_id.id, pt_attr_value_ids=av_ids
+        )
+        price_extra = sum(extra_prices.values())
+
+        # Return price using variant's lst_price instead of template list_price
+        return product_variant.lst_price + price_extra

--- a/ol_mrp_sale_price_rollup/models/product_config.py
+++ b/ol_mrp_sale_price_rollup/models/product_config.py
@@ -54,13 +54,5 @@ class ProductConfigSession(models.Model):
 
         value_ids = self.flatten_val_ids(value_ids)
 
-        # Fetch extra price based on attribute values
-        attr_val_obj = self.env["product.attribute.value"]
-        av_ids = attr_val_obj.browse(value_ids)
-        extra_prices = attr_val_obj.get_attribute_value_extra_prices(
-            product_tmpl_id=product_variant.product_tmpl_id.id, pt_attr_value_ids=av_ids
-        )
-        price_extra = sum(extra_prices.values())
-
         # Return price using variant's lst_price instead of template list_price
-        return product_variant.lst_price + price_extra
+        return product_variant.lst_price

--- a/ol_mrp_sale_price_rollup/wizard/__init__.py
+++ b/ol_mrp_sale_price_rollup/wizard/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2024 Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import product_configurator_sale

--- a/ol_mrp_sale_price_rollup/wizard/product_configurator_sale.py
+++ b/ol_mrp_sale_price_rollup/wizard/product_configurator_sale.py
@@ -1,0 +1,23 @@
+from odoo import models
+
+
+class ProductConfiguratorSale(models.TransientModel):
+    _inherit = "product.configurator.sale"
+
+    def action_config_done(self):
+        """Override to add price computation after the order line is created or updated"""
+        # Call the original method from the base module
+        res = super().action_config_done()
+
+        if self.order_line_id:
+            # Update the existing order line
+            self.order_line_id._compute_price_unit()  # Explicitly compute the price unit
+        else:
+            # Create a new order line and compute the price
+            new_line = self.env["sale.order.line"].search(
+                [("order_id", "=", self.order_id.id)], order="id desc", limit=1
+            )
+            if new_line:
+                new_line._compute_price_unit()  # Compute the price unit for the new line
+
+        return res


### PR DESCRIPTION
- Sale Orders: The line price wasn't getting set as well as the price on the session. It looks like it was pulling from the prod tmpl, so overriding _compute_cfg_price and get_cfg_price to pull from lst_price on variant seemed to work for the session price. Overriding action_config_done and triggering _compute_price_unit seems to then populate the price.
- Blanket Orders: Similar issue here, but needed to override onchange_product and add 'or self.product_id.lst_price' to the price_unit declaration.
- Sale Estimates: Also similar issue here, adding similar fix as blanket orders seemed to resolve the issue by adding 'or product.lst_price' to the price_unit declaration within the product_id_change method seemed to fix the issue. Note: That was the only change, all the other changes are formatting by black formatter.