### PR TITLE
[IMP] ol_mrp_plm_cancel (Hide cancel when creating record)

### DIFF
--- a/ol_mrp_plm_cancel/views/mrp_eco_view.xml
+++ b/ol_mrp_plm_cancel/views/mrp_eco_view.xml
@@ -12,7 +12,7 @@
                     name="action_cancel"
                     type="object"
                     class="btn_secondary"
-                    invisible="state in ('done','cancel')"
+                    invisible="not id or state and state in ('done','cancel')"
                     groups="mrp_plm.group_plm_user"
                     confirm="Are you sure you want to cancel this Engineering Change Request?"
                 />


### PR DESCRIPTION
Small change to hide the cancel button when creating a new ECO (Request from PM testing)

OSI Task: https://osi.mavenlink.com/workspaces/44078089/#tracker/904583088