### PR TITLE
[IMP] Move Internal Reference Field on Product Template and Product Variant.

### DIFF
--- a/ol_mrp_plm/__manifest__.py
+++ b/ol_mrp_plm/__manifest__.py
@@ -28,5 +28,6 @@
         "views/mrp_eco_stage.xml",
         "views/mrp_eco_views.xml",
         "views/product_template_view.xml",
+        "views/product_product_view.xml"
     ],
 }

--- a/ol_mrp_plm/views/product_product_view.xml
+++ b/ol_mrp_plm/views/product_product_view.xml
@@ -1,0 +1,21 @@
+<odoo>
+	<record id="mrp_plm.product_normal_form_view_inherit_version_plm" model="ir.ui.view">
+        <field name="name">product.product.view.form.inherit.version.plm</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_normal_form_view"/>
+        <field name="arch" type="xml">
+            <field name="default_code" position="replace"/>
+            <field name="detailed_type" position="after">
+                <label for="default_code"/>
+                <div class="o_row">
+                    <field name="default_code" nolabel="1" class="oe_inline" style="width: 55% !important;"/>
+                    <span style="width: 5% !important; display: inline-block;"/>
+                    <label for="version" class="oe_inline fw-bold" style="width: 20% !important; margin: 0;"/>
+                    <field name="version" nolabel="1" class="oe_inline" style="width: 20% !important;"/>
+                </div>
+            </field>
+
+        </field>
+    </record>
+
+</odoo>

--- a/ol_mrp_plm/views/product_template_view.xml
+++ b/ol_mrp_plm/views/product_template_view.xml
@@ -6,10 +6,11 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_only_form_view" />
         <field name="arch" type="xml">
-            <field name="default_code" position="replace">
+            <field name="default_code" position="replace"/>
+            <field name="detailed_type" position="after">
                     <label for="default_code" />
                     <div class="o_row" >
-                        <field name="default_code" required="1" nolabel="1" class="oe_inline" style="width: 55% !important;"/>
+                        <field name="default_code" required="1" nolabel="1" class="oe_inline" style="width: 50% !important;"/>
                         <span style="width: 5% !important; display: inline-block;"/>
                         <label for="version" class="oe_inline fw-bold" style="width: 20% !important; margin: 0;"/>
                         <field name="version" nolabel="1" class="oe_inline" style="width: 20% !important;"/>


### PR DESCRIPTION


Point 12) Move Internal Reference Field on Product Template and Product Variant. Field should be right under Product Type on both views.