### PR TITLE
[FIX] ol_warranty (Split Ship Error)

### DIFF
--- a/ol_warranty/models/stock_picking.py
+++ b/ol_warranty/models/stock_picking.py
@@ -30,9 +30,10 @@ class StockPicking(models.Model):
             if longest_warranty_period > 0:
                 for move_line in move.move_line_ids:
                     if move_line.lot_id:
-                        expiration_date = fields.Date.from_string(
-                            self.date_done
-                        ) + timedelta(days=longest_warranty_period * 365)
+                        done_date = self.date_done or fields.Date.context_today(self)
+                        expiration_date = done_date + timedelta(
+                            days=longest_warranty_period * 365
+                        )
                         move_line.lot_id.warranty_expiration_date = expiration_date
         return res
 


### PR DESCRIPTION
In split ship scenario, sometimes date_done isn't populated yet as it's creating the new DO, so we can just use the today's date

https://pm.opensourceintegrators.com/web#id=63236&cids=1&model=helpdesk.ticket&view_type=form