### PR TITLE
[FIX] ol_delivery/ol_product (Change x_shipping_height/weight/length)

### DIFF
--- a/ol_delivery/models/tools.py
+++ b/ol_delivery/models/tools.py
@@ -35,9 +35,9 @@ def get_product_data_from_order_lines_data(env, company, order_lines_data):
             pt.uuid,
             pt.default_code,
             pt."weight_dummy" AS "weight",
-            pt.x_shipping_height AS "height",
-            pt.x_shipping_length AS "length",
-            pt.x_shipping_width AS "width",
+            pt.height AS "height",
+            pt.length AS "length",
+            pt.width AS "width",
             pt.volume AS "volume",
             sb_ip.value_integer AS shipping_buffer,
             lp_ip.value_float AS "price",
@@ -72,7 +72,9 @@ def get_product_data_from_order_lines_data(env, company, order_lines_data):
         for order_line_data in order_lines_data:
             product_uuids.append(order_line_data.get("product_id"))
             product_uuids += [
-                x.get("product") for x in order_line_data.get("configuration", []) if x.get("product")
+                x.get("product")
+                for x in order_line_data.get("configuration", [])
+                if x.get("product")
             ]
         return list(set(product_uuids))
 
@@ -122,7 +124,9 @@ def get_product_data_from_order_lines_data(env, company, order_lines_data):
             line_cost = 0
             line_system_configuration = {}
 
-            product_uuids = [c.get("product") for c in configuration if c.get("product")]
+            product_uuids = [
+                c.get("product") for c in configuration if c.get("product")
+            ]
             products_data = get_product_data(company, product_uuids)
 
             for configuration_line in configuration:

--- a/ol_delivery/views/product_template.xml
+++ b/ol_delivery/views/product_template.xml
@@ -21,35 +21,6 @@
           </div>
         </div>
 
-        <label for="x_shipping_height"
-          invisible="product_variant_count &gt; 1 and not is_product_variant" />
-        <div class="o_row" name="x_shipping_height"
-          invisible="product_variant_count &gt; 1 and not is_product_variant">
-          <field name="x_shipping_height" class="oe_inline" />
-          <div name="height_cm" class="o_field_widget o_readonly_modifier o_field_char">
-            <span>cm</span>
-          </div>
-        </div>
-
-        <label for="x_shipping_length"
-          invisible="product_variant_count &gt; 1 and not is_product_variant" />
-        <div class="o_row" name="x_shipping_length"
-          invisible="product_variant_count &gt; 1 and not is_product_variant">
-          <field name="x_shipping_length" class="oe_inline" />
-          <div name="length_cm" class="o_field_widget o_readonly_modifier o_field_char">
-            <span>cm</span>
-          </div>
-        </div>
-
-        <label for="x_shipping_width"
-          invisible="product_variant_count &gt; 1 and not is_product_variant" />
-        <div class="o_row" name="x_shipping_width"
-          invisible="product_variant_count &gt; 1 and not is_product_variant">
-          <field name="x_shipping_width" class="oe_inline" />
-          <div name="width_cm" class="o_field_widget o_readonly_modifier o_field_char">
-            <span>cm</span>
-          </div>
-        </div>
       </div>
     </field>
   </record>

--- a/ol_product/views/product_template_views.xml
+++ b/ol_product/views/product_template_views.xml
@@ -5,20 +5,29 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_form_view"/>
         <field name="arch" type="xml">
-        	<xpath expr="//page[@name='inventory']//div[@name='volume']" position="after">
-        		<label for="length" invisible="product_variant_count &gt; 1 and not is_product_variant"/>
-                <div class="o_row" name="length" invisible="product_variant_count &gt; 1 and not is_product_variant">
-                    <field name="length" string="Length (cm)" class="oe_inline"/>
-                </div>
-
-                <label for="width" invisible="product_variant_count &gt; 1 and not is_product_variant"/>
-                <div class="o_row" name="width" invisible="product_variant_count &gt; 1 and not is_product_variant">
-                    <field name="width" string="Width (cm)" class="oe_inline"/>
-                </div>
-
-                <label for="height" invisible="product_variant_count &gt; 1 and not is_product_variant"/>
+        	<xpath expr="//page[@name='inventory']//div[@name='weight']" position="after">
+                <label for="height" invisible="product_variant_count &gt; 1 and not is_product_variant" />
                 <div class="o_row" name="height" invisible="product_variant_count &gt; 1 and not is_product_variant">
-                    <field name="height" string="Height (cm)" class="oe_inline"/>
+                    <field name="height" class="oe_inline" />
+                    <div name="height_cm" class="o_field_widget o_readonly_modifier o_field_char">
+                        <span>cm</span>
+                    </div>
+                </div>
+
+                <label for="length" invisible="product_variant_count &gt; 1 and not is_product_variant" />
+                <div class="o_row" name="length" invisible="product_variant_count &gt; 1 and not is_product_variant">
+                    <field name="length" class="oe_inline" />
+                    <div name="length_cm" class="o_field_widget o_readonly_modifier o_field_char">
+                        <span>cm</span>
+                    </div>
+                </div>
+
+                <label for="width" invisible="product_variant_count &gt; 1 and not is_product_variant" />
+                <div class="o_row" name="width" invisible="product_variant_count &gt; 1 and not is_product_variant">
+                    <field name="width" class="oe_inline" />
+                    <div name="width_cm" class="o_field_widget o_readonly_modifier o_field_char">
+                        <span>cm</span>
+                    </div>
                 </div>
         	</xpath>
         	<field name="uom_id" position="after">


### PR DESCRIPTION
We removed  x_shipping_height/weight/length fields so updated ol_delivery to use the other lenght/width/height fields we added and made view in ol_product to match what the ol_delivery module had added.