### PR TITLE
[FIX] ol_tier_validation (purchase tier exempt fields)

### DIFF
--- a/ol_tier_validation/data/tier_validation_exceptions.xml
+++ b/ol_tier_validation/data/tier_validation_exceptions.xml
@@ -43,6 +43,8 @@
             (4, ref('ol_purchase.field_purchase_order__shipping_notes')),
             (4, ref('purchase_stock.field_purchase_order__group_id')),
             (4, ref('purchase.field_purchase_order__order_line')),
+            (4, ref('purchase.field_purchase_order__priority')),
+            (4, ref('purchase.field_purchase_order__state')),
             ]" />
         <field name="allowed_to_write_after_validation" eval="True" />
         <field name="allowed_to_write_under_validation" eval="False" />


### PR DESCRIPTION
Add fields so locking PO doesn't cause error.