### PR TITLE
[FIX] Product Unit Price Not Being Pulled into Purchase Orders

### DIFF
--- a/ol_purchase/models/purchase_line.py
+++ b/ol_purchase/models/purchase_line.py
@@ -39,12 +39,12 @@ class PurchaseOrderLine(models.Model):
         """
         # Exclude lines that are already confirmed and have price_unit set
         self = self - self.filtered(
-            lambda l: l.order_id.state == "purchase" and l.price_unit
+            lambda l: l.id and l.order_id.state == "purchase" and l.price_unit
         )
         # Call the original compute method for the remaining records
         return super(
             PurchaseOrderLine, self
-        )._compute_price_unit_and_date_planned_and_name
+        )._compute_price_unit_and_date_planned_and_name()
 
     def _update_move_date_deadline(self, new_date):
         """


### PR DESCRIPTION
https://pm.opensourceintegrators.com/web#id=67243&cids=1&menu_id=218&action=1093&model=helpdesk.ticket&view_type=form