### PR TITLE
[FIX]ol_sale

### DIFF
--- a/ol_sale/models/sale_order.py
+++ b/ol_sale/models/sale_order.py
@@ -486,9 +486,10 @@ class SaleOrder(models.Model):
             sale.current_estimate_ship_date = False
             commitment_date =  sale.commitment_date
             current_estimate_ship_date = commitment_date
-            mrp_batch_data = self.env["mrp.production.batch"].search([("sale_order_ids","in",sale.id)])
-            if mrp_batch_data and mrp_batch_data.estimated_ship_date:
-                current_estimate_ship_date = max(mrp_batch_data.estimated_ship_date,commitment_date.date())
+            mrp_batch_datas = self.env["mrp.production.batch"].search([("sale_order_ids","in",sale.id)])
+            for mrp_batch_data in mrp_batch_datas:
+                if mrp_batch_data and mrp_batch_data.estimated_ship_date:
+                    current_estimate_ship_date = max(mrp_batch_data.estimated_ship_date,commitment_date.date())
             sale.current_estimate_ship_date = current_estimate_ship_date
 
 


### PR DESCRIPTION
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/addons/base/models/ir_model.py", line 1948, in _reflect_relation
    self.env.invalidate_all()
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/api.py", line 727, in invalidate_all
    self.flush_all()
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/api.py", line 737, in flush_all
    self._recompute_all()
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/api.py", line 733, in _recompute_all
    self[field.model_name]._recompute_field(field)
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/models.py", line 6975, in _recompute_field
    field.recompute(records)
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/fields.py", line 1379, in recompute
    apply_except_missing(self.compute_value, recs)
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/fields.py", line 1352, in apply_except_missing
    func(records)
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/fields.py", line 1401, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/odoo17_old/odoo/src/odoo/addons/sale_timesheet/models/sale_order.py", line 55, in _compute_field_value
    return super()._compute_field_value(field)
  File "/home/odoo/odoo17_old/odoo/src/odoo/addons/sale/models/sale_order.py", line 1730, in _compute_field_value
    return super()._compute_field_value(field)
  File "/home/odoo/odoo17_old/odoo/src/odoo/addons/mail/models/mail_thread.py", line 424, in _compute_field_value
    return super()._compute_field_value(field)
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/models.py", line 4921, in _compute_field_value
    fields.determine(field.compute, self)
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/fields.py", line 102, in determine
    return needle(*args)
  File "/home/odoo/odoo17_old/odoo/src/cs-osi-addons/ol_sale/models/sale_order.py", line 490, in _compute_current_estimate_ship_date
    if mrp_batch_data and mrp_batch_data.estimated_ship_date:
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/fields.py", line 1148, in __get__
    record.ensure_one()
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/models.py", line 5899, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: mrp.production.batch(1, 2)
