### PR TITLE
[FIX]Expected singleton: res.company(2, 1)

### DIFF
--- a/ol_sale/models/mrp_batch.py
+++ b/ol_sale/models/mrp_batch.py
@@ -73,6 +73,7 @@ class MrpProductionBatch(models.Model):
                 self.env["ir.config_parameter"]
                 .sudo()
                 .get_param("mrp_batch.default_produce_delay")
+                
             ) 
             use_manufacturing_lead = (
                 self.env["ir.config_parameter"]
@@ -100,7 +101,7 @@ class MrpProductionBatch(models.Model):
             if not forecast_expected_date:
                 continue
             forecast_expected_date = max(forecast_expected_date)
-            total_lead_time = int(self.company_id.manufacturing_lead) + int(default_produce_delay)
+            total_lead_time = int(record.company_id.manufacturing_lead) + int(default_produce_delay)
             if not record.rush_order:
                 if forecast_expected_date:
                     estimated_ship_date = forecast_expected_date + timedelta(days=total_lead_time)


### PR DESCRIPTION
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/fields.py", line 102, in determine
    return needle(*args)
  File "/home/odoo/odoo17_old/odoo/src/cs-osi-addons/ol_sale/models/sale_order.py", line 491, in _compute_current_estimate_ship_date
    if mrp_batch_data and mrp_batch_data.estimated_ship_date:
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/fields.py", line 1152, in __get__
    self.recompute(record)
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/fields.py", line 1379, in recompute
    apply_except_missing(self.compute_value, recs)
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/fields.py", line 1352, in apply_except_missing
    func(records)
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/fields.py", line 1401, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/odoo17_old/odoo/src/odoo/addons/mail/models/mail_thread.py", line 424, in _compute_field_value
    return super()._compute_field_value(field)
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/models.py", line 4921, in _compute_field_value
    fields.determine(field.compute, self)
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/fields.py", line 102, in determine
    return needle(*args)
  File "/home/odoo/odoo17_old/odoo/src/cs-osi-addons/ol_sale/models/mrp_batch.py", line 103, in _compute_estimated_ship_date
    total_lead_time = int(self.company_id.manufacturing_lead) + int(default_produce_delay)
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/fields.py", line 1148, in __get__
    record.ensure_one()
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/models.py", line 5899, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: res.company(2, 1)
