### PR TITLE
[FIX]AttributeError: 'bool' object has no attribute 'date'

### DIFF
--- a/ol_sale/models/sale_order.py
+++ b/ol_sale/models/sale_order.py
@@ -485,6 +485,8 @@ class SaleOrder(models.Model):
         for sale in self:
             sale.current_estimate_ship_date = False
             commitment_date =  sale.commitment_date
+            if not commitment_date:
+                continue
             current_estimate_ship_date = commitment_date
             mrp_batch_data = self.env["mrp.production.batch"].search([("sale_order_ids","in",sale.id)])
             if mrp_batch_data and mrp_batch_data.estimated_ship_date:


### PR DESCRIPTION
AttributeError: 'bool' object has no attribute 'date'
2025-10-14 11:17:14,034 4000519 CRITICAL v17_dev_0903_13_cs odoo.service.server: Failed to initialize database `v17_dev_0903_13_cs`. 
Traceback (most recent call last):
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/service/server.py", line 1362, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-16>", line 2, in new
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/modules/registry.py", line 110, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/modules/loading.py", line 481, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/modules/loading.py", line 366, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/modules/loading.py", line 207, in load_module_graph
    registry.init_models(env.cr, model_names, {'module': package.name}, new_install)
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/modules/registry.py", line 582, in init_models
    func()
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/addons/base/models/ir_model.py", line 1948, in _reflect_relation
    self.env.invalidate_all()
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/api.py", line 727, in invalidate_all
    self.flush_all()
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/api.py", line 737, in flush_all
    self._recompute_all()
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/api.py", line 733, in _recompute_all
    self[field.model_name]._recompute_field(field)
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/models.py", line 6975, in _recompute_field
    field.recompute(records)
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/fields.py", line 1379, in recompute
    apply_except_missing(self.compute_value, recs)
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/fields.py", line 1352, in apply_except_missing
    func(records)
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/fields.py", line 1401, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/odoo17_old/odoo/src/odoo/addons/sale_timesheet/models/sale_order.py", line 55, in _compute_field_value
    return super()._compute_field_value(field)
  File "/home/odoo/odoo17_old/odoo/src/odoo/addons/sale/models/sale_order.py", line 1730, in _compute_field_value
    return super()._compute_field_value(field)
  File "/home/odoo/odoo17_old/odoo/src/odoo/addons/mail/models/mail_thread.py", line 424, in _compute_field_value
    return super()._compute_field_value(field)
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/models.py", line 4921, in _compute_field_value
    fields.determine(field.compute, self)
  File "/home/odoo/odoo17_old/odoo/src/odoo/odoo/fields.py", line 102, in determine
    return needle(*args)
  File "/home/odoo/odoo17_old/odoo/src/cs-osi-addons/ol_sale/models/sale_order.py", line 492, in _compute_current_estimate_ship_date
    current_estimate_ship_date = max(mrp_batch_data.estimated_ship_date,commitment_date.date())
AttributeError: 'bool' object has no attribute 'date'
