### PR TITLE
[IMP] ol_product_state (Exclude Kits from MO Check)

### DIFF
--- a/ol_product_state/models/sale_order.py
+++ b/ol_product_state/models/sale_order.py
@@ -20,7 +20,9 @@ class SaleOrder(models.Model):
         errors = []
 
         for order in self:
-            for line in order.order_line.filtered(lambda l: l.bom_id):
+            for line in order.order_line.filtered(
+                lambda l: l.bom_id and not l.product_id.is_kits
+            ):
                 finished_product = line.product_id
 
                 def format_product(prod):


### PR DESCRIPTION
Kit products are causing a can't be manufactured error on sale orders and ONL wants them exempt from that check so this bypasses that.
https://pm.opensourceintegrators.com/web#id=67599&cids=1&model=helpdesk.ticket&view_type=form