### PR TITLE
Fix ValueError in UoM price computation for BOM structures

### DIFF
--- a/osi_uom_singleton_fix/__init__.py
+++ b/osi_uom_singleton_fix/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2024 - TODAY, Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/osi_uom_singleton_fix/__manifest__.py
+++ b/osi_uom_singleton_fix/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2024 - TODAY, Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "OSI UoM Singleton Fix",
+    "version": "18.0.1.0.0",
+    "license": "AGPL-3",
+    "summary": """
+    Fix singleton error in UoM _compute_price method when recordset is empty.
+    This fixes ValueError: Expected singleton: uom.uom() errors that occur
+    during BOM structure computations when UoM records are missing.
+    """,
+    "author": "Open Source Integrators",
+    "maintainers": ["Open Source Integrators"],
+    "website": "https://github.com/ursais/osi-addons",
+    "category": "Inventory",
+    "depends": ["uom"],
+    "data": [],
+    "installable": True,
+}

--- a/osi_uom_singleton_fix/models/__init__.py
+++ b/osi_uom_singleton_fix/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2024 - TODAY, Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import uom_uom

--- a/osi_uom_singleton_fix/models/uom_uom.py
+++ b/osi_uom_singleton_fix/models/uom_uom.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2024 - TODAY, Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class UoM(models.Model):
+    """Inherit UoM model to fix singleton error in _compute_price method."""
+
+    _inherit = "uom.uom"
+
+    def _compute_price(self, price, to_unit):
+        """
+        Override _compute_price to handle empty recordset case.
+
+        This fixes the ValueError: Expected singleton: uom.uom() error that
+        occurs during BOM structure computations when the UoM recordset is
+        empty (e.g., when bom.product_tmpl_id.uom_id is missing).
+
+        Args:
+            price (float): The price to convert
+            to_unit (recordset): The target UoM to convert to
+
+        Returns:
+            float: The converted price, or 0.0 if recordset is empty
+        """
+        # Guard clause: if recordset is empty, return 0.0 to prevent singleton error
+        if not self:
+            return 0.0
+
+        # Call parent method if recordset is not empty
+        return super()._compute_price(price, to_unit)


### PR DESCRIPTION
: Resolves ValueError: Expected singleton: uom.uom() that occurred when computing prices for BOM structures during Sales Order line creation. Added validation check in `_compute_price` method of UoM model to prevent calling `ensure_one()` on empty recordset. This addresses cascading field recomputations triggered by SO line addition where UoM lookup fails to find matching records. Fixes ticket #68357.