### PR TITLE
[#67591] Fix duplicate EU bank transfer emails in batch payments

### DIFF
--- a/osi_l10n_us_payment_nacha_email/models/account_batch_payment.py
+++ b/osi_l10n_us_payment_nacha_email/models/account_batch_payment.py
@@ -35,6 +35,7 @@ class AccountBatchPayment(models.Model):
         """
         Sends remittance emails to AP contacts per partner for this batch.
         Validates presence of AP contact and email.
+        Ensures emails are only sent once by setting the flag immediately after check.
         """
         template = self.env.ref(
             "osi_l10n_us_payment_nacha_email.email_template_detailed_payment_receipt"
@@ -45,6 +46,12 @@ class AccountBatchPayment(models.Model):
                 continue
             if batch.remittance_email_sent:
                 continue
+            
+            # Set flag immediately after check to prevent race conditions
+            # This ensures that even if _generate_export_file is called multiple times,
+            # only the first call will proceed to send emails
+            batch.write({"remittance_email_sent": True})
+            
             # Group payments by partner
             partner_groups = {}
             for payment in batch.payment_ids:
@@ -102,7 +109,6 @@ class AccountBatchPayment(models.Model):
                         "attachment_ids": [Command.set(payment_attachment.ids)],
                     },
                 )
-            batch.write({"remittance_email_sent": True})
 
     def _generate_export_file(self):
         data = super()._generate_export_file()


### PR DESCRIPTION
: Resolves duplicate EU bank transfer emails being sent multiple times for Sale Order 41000035954. This fix addresses the root cause in the osi_l10n_us_payment_nacha_email module within account_batch_payment.py where the '_generate_export_file' method was being called multiple times, causing email duplication. The solution implements proper flag checking and state management for the 'remittance_email_sent' flag to ensure emails are only sent once per batch payment. Reference: https://pm.opensourceintegrators.com/web#menu_id=218&cids=1&action=324&model=helpdesk.ticket&view_type=form&id=67591