### PR TITLE
[#67916] Fix email subject template syntax in invoice emails

### DIFF
--- a/account_invoice_email_fix/__init__.py
+++ b/account_invoice_email_fix/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2024 - TODAY, Open Source Integrators
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import models

--- a/account_invoice_email_fix/__manifest__.py
+++ b/account_invoice_email_fix/__manifest__.py
@@ -1,0 +1,26 @@
+# Copyright (C) 2024 - TODAY, Open Source Integrators
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+{
+    "name": "Account Invoice Email Fix",
+    "version": "18.0.1.0.0",
+    "category": "Accounting",
+    "license": "LGPL-3",
+    "summary": "Fix invoice email subject to properly display sale order or invoice name",
+    "description": """
+        Fixes the invoice email template subject line to properly display:
+        - Sale order name if a sale order exists (first sale order found)
+        - Invoice name if no sale order exists
+        Resolves issue where template syntax was showing raw template code instead of values.
+    """,
+    "author": "Open Source Integrators",
+    "maintainers": ["opensourceintegrators"],
+    "website": "https://github.com/ursais/osi-addons",
+    "depends": [
+        "account",
+        "sale",
+    ],
+    "data": [
+        "data/mail_template_data.xml",
+    ],
+    "installable": True,
+}

--- a/account_invoice_email_fix/data/mail_template_data.xml
+++ b/account_invoice_email_fix/data/mail_template_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Inherit invoice email template to fix subject line -->
+    <!-- 
+        This fixes the subject to show sale order name if exists, otherwise invoice name.
+        The Python code adds sale_order to the template context, so we can reference it directly.
+        The original template had incorrect syntax mixing ${...} with {{...}}.
+        The correct Jinja2 syntax is {{...}} only.
+    -->
+    <record id="account.email_template_edi_invoice" model="mail.template">
+        <field name="subject">Your Invoice {{ (sale_order and sale_order.name) or object.name or '' }}</field>
+    </record>
+</odoo>

--- a/account_invoice_email_fix/models/__init__.py
+++ b/account_invoice_email_fix/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2024 - TODAY, Open Source Integrators
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import mail_template

--- a/account_invoice_email_fix/models/mail_template.py
+++ b/account_invoice_email_fix/models/mail_template.py
@@ -1,0 +1,76 @@
+# Copyright (C) 2024 - TODAY, Open Source Integrators
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import api, models
+
+
+class MailTemplate(models.Model):
+    """
+    Inherit mail template to add sale_order to invoice email context.
+
+    This ensures the sale_order variable is available in invoice email templates,
+    allowing templates to reference sale_order.name directly.
+    """
+
+    _inherit = "mail.template"
+
+    @api.model
+    def _get_invoice_sale_order(self, invoice):
+        """
+        Get the first sale order associated with an invoice.
+
+        Args:
+            invoice: account.move record
+
+        Returns:
+            sale.order record or False if no sale order found
+        """
+        if not invoice or invoice.move_type not in ("out_invoice", "out_refund"):
+            return False
+
+        # Get sale orders from invoice lines
+        sale_orders = invoice.invoice_line_ids.sale_line_ids.order_id
+        if sale_orders:
+            return sale_orders[0]
+        return False
+
+    def _render_template(self, template_txt, model, res_ids, post_process=False):
+        """
+        Override to add sale_order to context for invoice email templates.
+
+        This method adds the sale_order variable to the template rendering context
+        so that templates can reference sale_order.name directly.
+        """
+        # Call parent first
+        result = super()._render_template(
+            template_txt, model, res_ids, post_process=post_process
+        )
+
+        # Only process invoice templates
+        if model != "account.move":
+            return result
+
+        # Add sale_order to context and re-render if needed
+        # Check if template uses sale_order variable
+        if "sale_order" in template_txt:
+            invoices = self.env[model].browse(res_ids)
+            for invoice in invoices:
+                if not invoice.exists():
+                    continue
+
+                sale_order = self._get_invoice_sale_order(invoice)
+
+                # Build context with sale_order
+                ctx = {
+                    "object": invoice,
+                    "sale_order": sale_order,
+                }
+
+                # Re-render template with updated context
+                rendered = self.env["ir.qweb"]._render(
+                    template_txt, ctx, raise_if_not_found=False
+                )
+                if rendered and invoice.id in result:
+                    result[invoice.id] = rendered
+
+        return result


### PR DESCRIPTION
: Corrected Jinja2 template syntax in invoice email subject line to properly display sale order or invoice names instead of raw template syntax. This resolves the formatting issue where ${(sale_order and sale_order.name) or {{ object.name }} or ''} was displaying literal template code rather than evaluated values. Fixes ticket #67916. The solution uses proper Odoo template syntax for conditional evaluation without nested braces that were causing the rendering error.