### PR TITLE
[#69592] Add test_field to sale.order form view

### DIFF
--- a/sale_test_field/__init__.py
+++ b/sale_test_field/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2024 Open Source Integrators
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import models

--- a/sale_test_field/__manifest__.py
+++ b/sale_test_field/__manifest__.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2024 Open Source Integrators
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+{
+    "name": "Sale Test Field",
+    "version": "18.0.1.0.0",
+    "category": "Sales",
+    "license": "LGPL-3",
+    "summary": "Adds test_field to sale.order form view",
+    "description": """
+        This module extends the sale.order model to add a test_field (string)
+        and displays it in the sale order form view.
+    """,
+    "author": "Open Source Integrators",
+    "maintainers": ["opensourceintegrators"],
+    "website": "https://github.com/ursais/osi-addons",
+    "depends": [
+        "sale_management",
+    ],
+    "data": [
+        "views/sale_order_view.xml",
+    ],
+    "installable": True,
+}

--- a/sale_test_field/models/__init__.py
+++ b/sale_test_field/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2024 Open Source Integrators
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import sale_order

--- a/sale_test_field/models/sale_order.py
+++ b/sale_test_field/models/sale_order.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2024 Open Source Integrators
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models
+
+
+class SaleOrder(models.Model):
+    """
+    Extends the sale.order model to add a test field.
+
+    This model adds a test_field (string) to sale orders for testing purposes.
+    """
+    _inherit = "sale.order"
+
+    test_field = fields.Char(
+        string="Test Field",
+        help="Test field for sale order customization",
+        tracking=True,
+    )

--- a/sale_test_field/views/sale_order_view.xml
+++ b/sale_test_field/views/sale_order_view.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2024 Open Source Integrators
+    License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+    
+    This view extends the sale order form to add the test_field.
+    The field is placed after the order name field for logical grouping.
+-->
+<odoo>
+    <record id="view_sale_order_test_field_inherit_form" model="ir.ui.view">
+        <field name="name">sale.order.test.field.inherit.form</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <!-- Add test_field after name field (order number) -->
+            <field name="name" position="after">
+                <field 
+                    name="test_field" 
+                    placeholder="Enter test value..."
+                    help="Test field for sale order customization"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
: This pull request addresses ticket #69592 by adding a new 'test_field' of type 'str' to the sale.order form view. The implementation follows Odoo's standard practices with two key changes: 1) Added the field definition to the Python model (sale.order) and 2) Extended the XML view to include the new field in the form view. The solution uses Odoo's standard inheritance pattern for views and assumes the base 'sale' module as the target. This enhancement provides additional functionality for tracking test-related information directly within the sales order form. Reference: https://pm.opensourceintegrators.com/web#menu_id=218&cids=1&action=324&model=helpdesk.ticket&view_type=form&id=69592