### PR TITLE
[#69878] Fix Delivery Slip formatting consistency across states

### DIFF
--- a/stock_delivery_slip_format/__init__.py
+++ b/stock_delivery_slip_format/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2024, Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/stock_delivery_slip_format/__manifest__.py
+++ b/stock_delivery_slip_format/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2024, Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Stock Delivery Slip Format",
+    "version": "18.0.1.0.0",
+    "license": "AGPL-3",
+    "summary": """
+    Ensures consistent delivery slip formatting with Coda Part No., Description,
+    Ordered (no decimals), and Delivered (no decimals) columns across all
+    delivery validation states.
+    """,
+    "author": "Open Source Integrators",
+    "maintainers": ["Open Source Integrators"],
+    "website": "https://github.com/ursais/osi-addons",
+    "category": "Inventory",
+    "depends": ["stock"],
+    "data": [
+        "reports/delivery_slip_report.xml",
+    ],
+    "installable": True,
+}

--- a/stock_delivery_slip_format/models/__init__.py
+++ b/stock_delivery_slip_format/models/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (C) 2024, Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import stock_picking
+from . import stock_move

--- a/stock_delivery_slip_format/models/stock_move.py
+++ b/stock_delivery_slip_format/models/stock_move.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2024, Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class StockMove(models.Model):
+    """Extend stock.move to add helper methods for delivery slip formatting."""
+
+    _inherit = "stock.move"
+
+    def _get_formatted_ordered_qty(self):
+        """
+        Get ordered quantity formatted as integer (no decimals).
+
+        :return: integer quantity as string
+        """
+        if not self.product_uom_qty:
+            return "0"
+        try:
+            return str(int(self.product_uom_qty))
+        except (ValueError, TypeError):
+            return "0"
+
+    def _get_formatted_delivered_qty(self):
+        """
+        Get delivered quantity formatted as integer (no decimals).
+        Sums qty_done from all move lines.
+
+        :return: integer quantity as string
+        """
+        if not self.move_line_ids:
+            return "0"
+        try:
+            # Filter out None values and sum qty_done
+            qty_done = sum(
+                line.qty_done for line in self.move_line_ids if line.qty_done
+            )
+            return str(int(qty_done)) if qty_done else "0"
+        except (ValueError, TypeError):
+            return "0"

--- a/stock_delivery_slip_format/models/stock_picking.py
+++ b/stock_delivery_slip_format/models/stock_picking.py
@@ -1,0 +1,7 @@
+# Copyright (C) 2024, Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+# This file is kept for potential future extensions
+# Currently, formatting logic is handled in stock.move model

--- a/stock_delivery_slip_format/reports/delivery_slip_report.xml
+++ b/stock_delivery_slip_format/reports/delivery_slip_report.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <!-- Inherit stock delivery slip report template -->
+        <template id="report_deliveryslip_inherit" inherit_id="stock.report_deliveryslip">
+            <!-- Replace table header to ensure consistent column headers -->
+            <!-- Target the first table header row that contains move-related data -->
+            <xpath expr="//table[contains(@class, 'table')]//thead/tr" position="replace">
+                <tr>
+                    <th>Coda Part No.</th>
+                    <th>Description</th>
+                    <th class="text-right">Ordered</th>
+                    <th class="text-right">Delivered</th>
+                </tr>
+            </xpath>
+            <!-- Replace table body to ensure consistent formatting with no decimals -->
+            <!-- Target the tbody that contains move lines -->
+            <xpath expr="//table[contains(@class, 'table')]//tbody" position="replace">
+                <tbody>
+                    <t t-foreach="docs" t-as="doc">
+                        <t t-foreach="doc.move_ids_without_package" t-as="move">
+                            <tr>
+                                <td>
+                                    <span t-esc="move.product_id.default_code or ''"/>
+                                </td>
+                                <td>
+                                    <span t-esc="move.product_id.display_name or ''"/>
+                                </td>
+                                <td class="text-right">
+                                    <span t-esc="move._get_formatted_ordered_qty()"/>
+                                </td>
+                                <td class="text-right">
+                                    <span t-esc="move._get_formatted_delivered_qty()"/>
+                                </td>
+                            </tr>
+                        </t>
+                    </t>
+                </tbody>
+            </xpath>
+        </template>
+    </data>
+</odoo>


### PR DESCRIPTION
: This pull request resolves the Delivery Slip formatting inconsistency across different delivery validation states (Draft, Waiting, Ready, Done, Cancelled). The QWeb report template in the stock module has been modified to enforce a consistent layout that always displays 'Coda Part No.', 'Description', 'Ordered' (no decimals), and 'Delivered' (no decimals) fields.