### PR TITLE
[CI] Update pre-commit workflow actions for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,8 +8,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
-      - uses: pre-commit/action@v2.0.0
+          python-version: "3.12"
+      - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
## Summary

- Update `actions/checkout@v2` → `actions/checkout@v4`
- Update `actions/setup-python@v2` → `actions/setup-python@v5`
- Update `pre-commit/action@v2.0.0` → `pre-commit/action@v3.0.1`
- Bump Python version from 3.9 to 3.12

## Why

GitHub forced all Actions to run on Node.js 24 starting June 2, 2026. The previous action versions (`@v2`) only support Node.js 20, causing the pre-commit CI to fail for all PRs targeting 17.0.

## Test plan

- [x] Verify the pre-commit CI job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)