### PR TITLE
[UPD] Remove wolfhall maintainer; scope generate/publish CI

### DIFF
--- a/.github/scripts/changed_addons.sh
+++ b/.github/scripts/changed_addons.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# List installable addon directories touched between two git refs.
+# Usage: changed_addons.sh [base_sha] [head_sha]
+# If base is empty/missing/zero, list all addons that have pyproject.toml.
+set -euo pipefail
+
+base="${1:-}"
+head_ref="${2:-HEAD}"
+
+is_addon() {
+  local dir="$1"
+  [[ -f "${dir}/__manifest__.py" || -f "${dir}/__openerp__.py" ]]
+}
+
+list_all_addons() {
+  find . -mindepth 2 -maxdepth 2 -name pyproject.toml -printf '%h\n' \
+    | sed 's|^\./||' \
+    | sort -u \
+    | while read -r dir; do
+        if is_addon "${dir}"; then
+          echo "${dir}"
+        fi
+      done
+}
+
+if [[ -z "${base}" || "${base}" =~ ^0+$ ]]; then
+  list_all_addons
+  exit 0
+fi
+
+git diff --name-only "${base}" "${head_ref}" \
+  | awk -F/ 'NF >= 2 { print $1 }' \
+  | sort -u \
+  | while read -r dir; do
+      if is_addon "${dir}" && [[ -f "${dir}/pyproject.toml" ]]; then
+        echo "${dir}"
+      fi
+    done

--- a/.github/scripts/ensure_readme_fragments.sh
+++ b/.github/scripts/ensure_readme_fragments.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Ensure OCA-style readme/ fragments exist for each given addon.
+# Usage: ensure_readme_fragments.sh addon1 [addon2 ...]
+set -euo pipefail
+
+python_summary() {
+  local addon="$1"
+  python3 - <<PY
+import ast
+from pathlib import Path
+manifest = Path("${addon}") / "__manifest__.py"
+if not manifest.exists():
+    manifest = Path("${addon}") / "__openerp__.py"
+data = ast.literal_eval(manifest.read_text())
+print(data.get("summary") or data.get("name") or "${addon}")
+PY
+}
+
+for addon in "$@"; do
+  [[ -d "${addon}" ]] || continue
+  mkdir -p "${addon}/readme"
+  summary="$(python_summary "${addon}")"
+
+  if [[ ! -f "${addon}/readme/DESCRIPTION.md" ]]; then
+    printf '%s\n' "${summary}" >"${addon}/readme/DESCRIPTION.md"
+    echo "Created ${addon}/readme/DESCRIPTION.md"
+  fi
+  if [[ ! -f "${addon}/readme/USAGE.md" ]]; then
+    cat >"${addon}/readme/USAGE.md" <<EOF
+To use this module, you need to:
+
+1. Go to the related application menu.
+2. Review the new features provided by this module.
+EOF
+    echo "Created ${addon}/readme/USAGE.md"
+  fi
+  if [[ ! -f "${addon}/readme/CONFIGURE.md" ]]; then
+    cat >"${addon}/readme/CONFIGURE.md" <<'EOF'
+No special configuration is required beyond installing the module and assigning
+the relevant security groups to users.
+EOF
+    echo "Created ${addon}/readme/CONFIGURE.md"
+  fi
+  if [[ ! -f "${addon}/readme/CONTRIBUTORS.md" ]]; then
+    cat >"${addon}/readme/CONTRIBUTORS.md" <<'EOF'
+- [Open Source Integrators](https://www.opensourceintegrators.com)
+- [Gray Matter Logic](https://www.graymatterlogic.com):
+  - Maxime Chambreuil <maxime.chambreuil@graymatterlogic.com>
+EOF
+    echo "Created ${addon}/readme/CONTRIBUTORS.md"
+  fi
+  if [[ ! -f "${addon}/readme/CREDITS.md" ]]; then
+    cat >"${addon}/readme/CREDITS.md" <<'EOF'
+The development of this module was originally supported by Open Source Integrators.
+EOF
+    echo "Created ${addon}/readme/CREDITS.md"
+  fi
+done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,15 @@ on:
     types:
       - published
   workflow_dispatch:
+    inputs:
+      addon:
+        description: "Addon directory to publish (empty = all changed, or all on release)"
+        required: false
+        type: string
 
 jobs:
   discover:
-    name: Discover addon packages
+    name: Discover addons to publish
     runs-on: ubuntu-latest
     outputs:
       addons: ${{ steps.set-matrix.outputs.addons }}
@@ -19,17 +24,30 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 0
       - id: set-matrix
-        name: List addons with pyproject.toml
+        name: Resolve addon list
         run: |
-          addons="$(
-            find . -mindepth 2 -maxdepth 2 -name pyproject.toml -printf '%h\n' \
-              | sed 's|^\./||' \
-              | sort \
-              | jq -R -s -c 'split("\n") | map(select(length > 0))'
-          )"
+          set -euo pipefail
+          chmod +x .github/scripts/changed_addons.sh
+
+          if [ -n "${{ inputs.addon }}" ]; then
+            addons='["${{ inputs.addon }}"]'
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            mapfile -t list < <(.github/scripts/changed_addons.sh "${{ github.event.before }}" "${{ github.sha }}")
+            if [ "${#list[@]}" -eq 0 ]; then
+              addons='[]'
+            else
+              addons="$(printf '%s\n' "${list[@]}" | jq -R -s -c 'split("\n") | map(select(length > 0))')"
+            fi
+          else
+            # release or dispatch without addon: publish every packaged addon
+            mapfile -t list < <(.github/scripts/changed_addons.sh)
+            addons="$(printf '%s\n' "${list[@]}" | jq -R -s -c 'split("\n") | map(select(length > 0))')"
+          fi
+
           echo "addons=${addons}" >> "${GITHUB_OUTPUT}"
-          echo "Found addons: ${addons}"
+          echo "Addons to publish: ${addons}"
 
   publish:
     name: Publish ${{ matrix.addon }}
@@ -51,7 +69,6 @@ jobs:
         run: python -m pip install --upgrade pip build
       - name: Build ${{ matrix.addon }}
         env:
-          # Publish the exact manifest version (no .postN git suffix).
           WHOOL_POST_VERSION_STRATEGY_OVERRIDE: none
         run: |
           mkdir -p dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 0
       - name: Install addons and dependencies
         run: oca_install_addons
       - name: Check licenses
@@ -70,21 +71,37 @@ jobs:
           git config user.name "${OCA_GIT_USER_NAME:-osi-ci}"
           git config user.email "${OCA_GIT_USER_EMAIL:-osi-ci@opensourceintegrators.com}"
 
+          chmod +x .github/scripts/changed_addons.sh .github/scripts/ensure_readme_fragments.sh
+          mapfile -t CHANGED_ADDONS < <(
+            .github/scripts/changed_addons.sh "${{ github.event.before }}" "${{ github.sha }}"
+          )
+          if [ "${#CHANGED_ADDONS[@]}" -eq 0 ]; then
+            echo "No packaged addons changed; skipping generated-file updates."
+            exit 0
+          fi
+          echo "Changed addons: ${CHANGED_ADDONS[*]}"
+
           pip install click-odoo-contrib \
             "oca-maintainers-tools @ git+https://github.com/OCA/maintainer-tools.git@1faff6d90f8a0d189aad3f148c5fc72df3117193"
 
-          # 1) Export .pot and msgmerge existing .po files
-          click-odoo-makepot --addons-dir "${ADDONS_DIR:-.}" -d "${PGDATABASE}" \
-            --msgmerge-if-new-pot --commit --log-level=debug
+          # 0) Ensure OCA readme/ fragments exist for changed addons
+          .github/scripts/ensure_readme_fragments.sh "${CHANGED_ADDONS[@]}"
+          if [ -n "$(git status --porcelain -- '*/readme/*')" ]; then
+            git add -- '*/readme/*'
+            git commit -m "[UPD] Ensure readme fragments for changed addons"
+          fi
 
-          # 2) Ensure fr, es, pt, de, it .po files exist for every addon .pot
+          # 1) Export .pot for installed addons, then keep i18n changes only
+          #    for modules touched in this push.
+          click-odoo-makepot --addons-dir "${ADDONS_DIR:-.}" -d "${PGDATABASE}" \
+            --msgmerge-if-new-pot --log-level=debug
           apt-get update -qq
           apt-get install -y -qq gettext
-          for pot in */i18n/*.pot; do
+          for addon in "${CHANGED_ADDONS[@]}"; do
+            pot="${addon}/i18n/${addon}.pot"
             [ -f "$pot" ] || continue
-            addon_i18n="$(dirname "$pot")"
             for lang in ${LANGS}; do
-              po="${addon_i18n}/${lang}.po"
+              po="${addon}/i18n/${lang}.po"
               if [ ! -f "$po" ]; then
                 msginit --no-translator --locale="${lang}" --input="$pot" --output-file="$po"
               else
@@ -92,14 +109,34 @@ jobs:
               fi
             done
           done
-          if [ -n "$(git status --porcelain -- '*/i18n/*.po')" ]; then
-            git add -- '*/i18n/*.po'
-            git commit -m "[UPD] Ensure fr, es, pt, de, it translation files"
+          # Discard i18n noise from untouched addons
+          for i18n_dir in */i18n; do
+            addon="$(dirname "${i18n_dir}")"
+            keep=0
+            for changed in "${CHANGED_ADDONS[@]}"; do
+              if [ "${addon}" = "${changed}" ]; then
+                keep=1
+                break
+              fi
+            done
+            if [ "${keep}" -eq 0 ]; then
+              git checkout -- "${i18n_dir}" 2>/dev/null || true
+            fi
+          done
+          for addon in "${CHANGED_ADDONS[@]}"; do
+            git add -- "${addon}/i18n/" 2>/dev/null || true
+          done
+          if [ -n "$(git status --porcelain -- '*/i18n/*')" ]; then
+            git commit -m "[UPD] Update translations for changed addons"
           fi
 
-          # 3) Regenerate per-addon README.rst from readme/ fragments
+          # 2) Regenerate README.rst only for changed addons
+          readme_args=()
+          for addon in "${CHANGED_ADDONS[@]}"; do
+            readme_args+=(--addon-dir="${addon}")
+          done
           oca-gen-addon-readme \
-            --addons-dir=. \
+            "${readme_args[@]}" \
             --branch=19.0 \
             --org-name=ursais \
             --repo-name=osi-addons \
@@ -107,8 +144,8 @@ jobs:
             --keep-source-digest \
             --convert-fragments-to-markdown
 
-          # 4) Update repository README.md addons table
+          # 3) Update repository README.md addons table
           oca-gen-addons-table --commit
 
-          # 5) Push generated commits if remote did not move
+          # 4) Push generated commits if remote did not move
           oca_git_push_if_remote_did_not_change "${PUSH_URL}"

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Available addons
 ----------------
 addon | version | maintainers | summary
 --- | --- | --- | ---
-[fieldservice_mobile](fieldservice_mobile/) | 19.0.1.1.0 | [![wolfhall](https://github.com/wolfhall.png?size=30px)](https://github.com/wolfhall) [![max3903](https://github.com/max3903.png?size=30px)](https://github.com/max3903) | Field Service Mobile Backend Support.
-[fieldservice_tracking](fieldservice_tracking/) | 19.0.1.0.0 | [![wolfhall](https://github.com/wolfhall.png?size=30px)](https://github.com/wolfhall) [![max3903](https://github.com/max3903.png?size=30px)](https://github.com/max3903) | This module will add tracking functionality in Fieldservice.
+[fieldservice_mobile](fieldservice_mobile/) | 19.0.1.1.0 | [![max3903](https://github.com/max3903.png?size=30px)](https://github.com/max3903) | Field Service Mobile Backend Support.
+[fieldservice_tracking](fieldservice_tracking/) | 19.0.1.0.0 | [![max3903](https://github.com/max3903.png?size=30px)](https://github.com/max3903) | This module will add tracking functionality in Fieldservice.
 
 [//]: # (end addons)
 <!-- prettier-ignore-end -->

--- a/fieldservice_mobile/README.rst
+++ b/fieldservice_mobile/README.rst
@@ -177,16 +177,13 @@ Integrators.
 Maintainers
 -----------
 
-.. |maintainer-wolfhall| image:: https://github.com/wolfhall.png?size=40px
-    :target: https://github.com/wolfhall
-    :alt: wolfhall
 .. |maintainer-max3903| image:: https://github.com/max3903.png?size=40px
     :target: https://github.com/max3903
     :alt: max3903
 
-Current maintainers:
+Current maintainer:
 
-|maintainer-wolfhall| |maintainer-max3903| 
+|maintainer-max3903| 
 
 This module is part of the `ursais/osi-addons <https://github.com/ursais/osi-addons/tree/19.0/fieldservice_mobile>`_ project on GitHub.
 

--- a/fieldservice_mobile/__manifest__.py
+++ b/fieldservice_mobile/__manifest__.py
@@ -34,5 +34,5 @@
         "views/mobile_feature_line.xml",
     ],
     "development_status": "Beta",
-    "maintainers": ["wolfhall", "max3903"],
+    "maintainers": ["max3903"],
 }

--- a/fieldservice_mobile/static/description/index.html
+++ b/fieldservice_mobile/static/description/index.html
@@ -533,8 +533,8 @@ Integrators.</p>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-12">Maintainers</a></h2>
-<p>Current maintainers:</p>
-<p><a class="reference external image-reference" href="https://github.com/wolfhall"><img alt="wolfhall" src="https://github.com/wolfhall.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/max3903"><img alt="max3903" src="https://github.com/max3903.png?size=40px" /></a></p>
+<p>Current maintainer:</p>
+<p><a class="reference external image-reference" href="https://github.com/max3903"><img alt="max3903" src="https://github.com/max3903.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/ursais/osi-addons/tree/19.0/fieldservice_mobile">ursais/osi-addons</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>

--- a/fieldservice_tracking/README.rst
+++ b/fieldservice_tracking/README.rst
@@ -96,16 +96,13 @@ Integrators and Serpent Consulting Services Pvt. Ltd.
 Maintainers
 -----------
 
-.. |maintainer-wolfhall| image:: https://github.com/wolfhall.png?size=40px
-    :target: https://github.com/wolfhall
-    :alt: wolfhall
 .. |maintainer-max3903| image:: https://github.com/max3903.png?size=40px
     :target: https://github.com/max3903
     :alt: max3903
 
-Current maintainers:
+Current maintainer:
 
-|maintainer-wolfhall| |maintainer-max3903| 
+|maintainer-max3903| 
 
 This module is part of the `ursais/osi-addons <https://github.com/ursais/osi-addons/tree/19.0/fieldservice_tracking>`_ project on GitHub.
 

--- a/fieldservice_tracking/__manifest__.py
+++ b/fieldservice_tracking/__manifest__.py
@@ -22,7 +22,6 @@
     "installable": True,
     "development_status": "Beta",
     "maintainers": [
-        "wolfhall",
         "max3903",
     ],
 }

--- a/fieldservice_tracking/static/description/index.html
+++ b/fieldservice_tracking/static/description/index.html
@@ -452,8 +452,8 @@ Integrators and Serpent Consulting Services Pvt. Ltd.</p>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
-<p>Current maintainers:</p>
-<p><a class="reference external image-reference" href="https://github.com/wolfhall"><img alt="wolfhall" src="https://github.com/wolfhall.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/max3903"><img alt="max3903" src="https://github.com/max3903.png?size=40px" /></a></p>
+<p>Current maintainer:</p>
+<p><a class="reference external image-reference" href="https://github.com/max3903"><img alt="max3903" src="https://github.com/max3903.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/ursais/osi-addons/tree/19.0/fieldservice_tracking">ursais/osi-addons</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>


### PR DESCRIPTION
## Summary
- Remove `wolfhall` from maintainers on `fieldservice_mobile` and `fieldservice_tracking` (regenerated READMEs / addons table).
- Ensure OCA `readme/` fragments exist for changed addons.
- Scope pot/po + README generation and PyPI publish to **only addons touched in the push/PR**.

## Test plan
- [ ] Confirm manifests list only `max3903`
- [ ] On merge to `19.0`, publish job matrix includes only changed addons
- [ ] Generated-file update step skips when no packaged addon paths changed