### PR TITLE
[FIX] ci: bump GitHub Actions to Node.js 24 runtimes

### DIFF
--- a/.github/scripts/changed_addons.sh
+++ b/.github/scripts/changed_addons.sh
@@ -1,29 +1,30 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # List installable addon directories touched between two git refs.
 # Usage: changed_addons.sh [base_sha] [head_sha]
 # If base is empty/missing/zero, list all addons that have pyproject.toml.
-set -euo pipefail
+set -eu
 
 base="${1:-}"
 head_ref="${2:-HEAD}"
 
 is_addon() {
-  local dir="$1"
-  [[ -f "${dir}/__manifest__.py" || -f "${dir}/__openerp__.py" ]]
+  dir="$1"
+  [ -f "${dir}/__manifest__.py" ] || [ -f "${dir}/__openerp__.py" ]
 }
 
 list_all_addons() {
   find . -mindepth 2 -maxdepth 2 -name pyproject.toml -printf '%h\n' \
     | sed 's|^\./||' \
     | sort -u \
-    | while read -r dir; do
+    | while IFS= read -r dir; do
         if is_addon "${dir}"; then
           echo "${dir}"
         fi
       done
 }
 
-if [[ -z "${base}" || "${base}" =~ ^0+$ ]]; then
+# Empty or all-zero SHA (new branch / no previous tip)
+if [ -z "${base}" ] || printf '%s' "${base}" | grep -Eq '^0+$'; then
   list_all_addons
   exit 0
 fi
@@ -31,8 +32,8 @@ fi
 git diff --name-only "${base}" "${head_ref}" \
   | awk -F/ 'NF >= 2 { print $1 }' \
   | sort -u \
-  | while read -r dir; do
-      if is_addon "${dir}" && [[ -f "${dir}/pyproject.toml" ]]; then
+  | while IFS= read -r dir; do
+      if is_addon "${dir}" && [ -f "${dir}/pyproject.toml" ]; then
         echo "${dir}"
       fi
     done

--- a/.github/scripts/ensure_readme_fragments.sh
+++ b/.github/scripts/ensure_readme_fragments.sh
@@ -1,10 +1,10 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Ensure OCA-style readme/ fragments exist for each given addon.
 # Usage: ensure_readme_fragments.sh addon1 [addon2 ...]
-set -euo pipefail
+set -eu
 
 python_summary() {
-  local addon="$1"
+  addon="$1"
   python3 - <<PY
 import ast
 from pathlib import Path
@@ -17,15 +17,15 @@ PY
 }
 
 for addon in "$@"; do
-  [[ -d "${addon}" ]] || continue
+  [ -d "${addon}" ] || continue
   mkdir -p "${addon}/readme"
   summary="$(python_summary "${addon}")"
 
-  if [[ ! -f "${addon}/readme/DESCRIPTION.md" ]]; then
+  if [ ! -f "${addon}/readme/DESCRIPTION.md" ]; then
     printf '%s\n' "${summary}" >"${addon}/readme/DESCRIPTION.md"
     echo "Created ${addon}/readme/DESCRIPTION.md"
   fi
-  if [[ ! -f "${addon}/readme/USAGE.md" ]]; then
+  if [ ! -f "${addon}/readme/USAGE.md" ]; then
     cat >"${addon}/readme/USAGE.md" <<EOF
 To use this module, you need to:
 
@@ -34,14 +34,14 @@ To use this module, you need to:
 EOF
     echo "Created ${addon}/readme/USAGE.md"
   fi
-  if [[ ! -f "${addon}/readme/CONFIGURE.md" ]]; then
+  if [ ! -f "${addon}/readme/CONFIGURE.md" ]; then
     cat >"${addon}/readme/CONFIGURE.md" <<'EOF'
 No special configuration is required beyond installing the module and assigning
 the relevant security groups to users.
 EOF
     echo "Created ${addon}/readme/CONFIGURE.md"
   fi
-  if [[ ! -f "${addon}/readme/CONTRIBUTORS.md" ]]; then
+  if [ ! -f "${addon}/readme/CONTRIBUTORS.md" ]; then
     cat >"${addon}/readme/CONTRIBUTORS.md" <<'EOF'
 - [Open Source Integrators](https://www.opensourceintegrators.com)
 - [Gray Matter Logic](https://www.graymatterlogic.com):
@@ -49,7 +49,7 @@ EOF
 EOF
     echo "Created ${addon}/readme/CONTRIBUTORS.md"
   fi
-  if [[ ! -f "${addon}/readme/CREDITS.md" ]]; then
+  if [ ! -f "${addon}/readme/CREDITS.md" ]; then
     cat >"${addon}/readme/CREDITS.md" <<'EOF'
 The development of this module was originally supported by Open Source Integrators.
 EOF

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,13 +13,13 @@ jobs:
   pre-commit:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,23 +27,24 @@ jobs:
           fetch-depth: 0
       - id: set-matrix
         name: Resolve addon list
+        shell: bash
         run: |
           set -euo pipefail
           chmod +x .github/scripts/changed_addons.sh
 
           if [ -n "${{ inputs.addon }}" ]; then
-            addons='["${{ inputs.addon }}"]'
+            addons="$(printf '%s\n' "${{ inputs.addon }}" | jq -R -s -c 'split("\n") | map(select(length > 0))')"
           elif [ "${{ github.event_name }}" = "push" ]; then
-            mapfile -t list < <(.github/scripts/changed_addons.sh "${{ github.event.before }}" "${{ github.sha }}")
-            if [ "${#list[@]}" -eq 0 ]; then
-              addons='[]'
-            else
-              addons="$(printf '%s\n' "${list[@]}" | jq -R -s -c 'split("\n") | map(select(length > 0))')"
-            fi
+            addons="$(
+              .github/scripts/changed_addons.sh "${{ github.event.before }}" "${{ github.sha }}" \
+                | jq -R -s -c 'split("\n") | map(select(length > 0))'
+            )"
           else
             # release or dispatch without addon: publish every packaged addon
-            mapfile -t list < <(.github/scripts/changed_addons.sh)
-            addons="$(printf '%s\n' "${list[@]}" | jq -R -s -c 'split("\n") | map(select(length > 0))')"
+            addons="$(
+              .github/scripts/changed_addons.sh \
+                | jq -R -s -c 'split("\n") | map(select(length > 0))'
+            )"
           fi
 
           echo "addons=${addons}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       addons: ${{ steps.set-matrix.outputs.addons }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -59,10 +59,10 @@ jobs:
       matrix:
         addon: ${{ fromJson(needs.discover.outputs.addons) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Install build

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Stale PRs and issues policy
-        uses: actions/stale@v4
+        uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # General settings.
@@ -45,7 +45,7 @@ jobs:
       # * Issues that are pending more information
       # * Except Issues marked as "no stale"
       - name: Needs more information stale issues policy
-        uses: actions/stale@v4
+        uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           ascending: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     env:
       OCA_ENABLE_CHECKLOG_ODOO: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -49,7 +49,7 @@ jobs:
         run: oca_init_test_database
       - name: Run tests
         run: oca_run_tests
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Update README, .pot and translation files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,11 +55,13 @@ jobs:
       - name: Update README, .pot and translation files
         # secrets cannot be referenced in `if:` expressions; skip inside the step instead
         if: ${{ matrix.update_generated == 'true' && github.event_name == 'push' }}
+        # oca-ci containers default to sh; use bash for arrays / process subst safety
+        shell: bash
         env:
           LANGS: fr es pt de it
           GIT_PUSH_TOKEN: ${{ secrets.GIT_PUSH_TOKEN }}
         run: |
-          set -ex
+          set -euo pipefail
           if [ -z "${GIT_PUSH_TOKEN}" ]; then
             echo "GIT_PUSH_TOKEN secret is not set; skipping generated-file updates."
             exit 0
@@ -72,20 +74,22 @@ jobs:
           git config user.email "${OCA_GIT_USER_EMAIL:-osi-ci@opensourceintegrators.com}"
 
           chmod +x .github/scripts/changed_addons.sh .github/scripts/ensure_readme_fragments.sh
-          mapfile -t CHANGED_ADDONS < <(
-            .github/scripts/changed_addons.sh "${{ github.event.before }}" "${{ github.sha }}"
-          )
-          if [ "${#CHANGED_ADDONS[@]}" -eq 0 ]; then
+          CHANGED_FILE="$(mktemp)"
+          .github/scripts/changed_addons.sh "${{ github.event.before }}" "${{ github.sha }}" >"${CHANGED_FILE}"
+          if [ ! -s "${CHANGED_FILE}" ]; then
             echo "No packaged addons changed; skipping generated-file updates."
+            rm -f "${CHANGED_FILE}"
             exit 0
           fi
-          echo "Changed addons: ${CHANGED_ADDONS[*]}"
+          echo "Changed addons:"
+          cat "${CHANGED_FILE}"
 
           pip install click-odoo-contrib \
             "oca-maintainers-tools @ git+https://github.com/OCA/maintainer-tools.git@1faff6d90f8a0d189aad3f148c5fc72df3117193"
 
           # 0) Ensure OCA readme/ fragments exist for changed addons
-          .github/scripts/ensure_readme_fragments.sh "${CHANGED_ADDONS[@]}"
+          # shellcheck disable=SC2046
+          .github/scripts/ensure_readme_fragments.sh $(cat "${CHANGED_FILE}")
           if [ -n "$(git status --porcelain -- '*/readme/*')" ]; then
             git add -- '*/readme/*'
             git commit -m "[UPD] Ensure readme fragments for changed addons"
@@ -97,7 +101,8 @@ jobs:
             --msgmerge-if-new-pot --log-level=debug
           apt-get update -qq
           apt-get install -y -qq gettext
-          for addon in "${CHANGED_ADDONS[@]}"; do
+          while IFS= read -r addon; do
+            [ -n "${addon}" ] || continue
             pot="${addon}/i18n/${addon}.pot"
             [ -f "$pot" ] || continue
             for lang in ${LANGS}; do
@@ -108,33 +113,28 @@ jobs:
                 msgmerge --update --backup=none "$po" "$pot"
               fi
             done
-          done
+          done <"${CHANGED_FILE}"
           # Discard i18n noise from untouched addons
           for i18n_dir in */i18n; do
             addon="$(dirname "${i18n_dir}")"
-            keep=0
-            for changed in "${CHANGED_ADDONS[@]}"; do
-              if [ "${addon}" = "${changed}" ]; then
-                keep=1
-                break
-              fi
-            done
-            if [ "${keep}" -eq 0 ]; then
+            if ! grep -qxF "${addon}" "${CHANGED_FILE}"; then
               git checkout -- "${i18n_dir}" 2>/dev/null || true
             fi
           done
-          for addon in "${CHANGED_ADDONS[@]}"; do
+          while IFS= read -r addon; do
+            [ -n "${addon}" ] || continue
             git add -- "${addon}/i18n/" 2>/dev/null || true
-          done
+          done <"${CHANGED_FILE}"
           if [ -n "$(git status --porcelain -- '*/i18n/*')" ]; then
             git commit -m "[UPD] Update translations for changed addons"
           fi
 
           # 2) Regenerate README.rst only for changed addons
           readme_args=()
-          for addon in "${CHANGED_ADDONS[@]}"; do
+          while IFS= read -r addon; do
+            [ -n "${addon}" ] || continue
             readme_args+=(--addon-dir="${addon}")
-          done
+          done <"${CHANGED_FILE}"
           oca-gen-addon-readme \
             "${readme_args[@]}" \
             --branch=19.0 \
@@ -149,3 +149,4 @@ jobs:
 
           # 4) Push generated commits if remote did not move
           oca_git_push_if_remote_did_not_change "${PUSH_URL}"
+          rm -f "${CHANGED_FILE}"


### PR DESCRIPTION
## Summary
- Update `actions/checkout`, `setup-python`, `cache`, `stale`, and `codecov` to current majors that run on Node.js 24.
- Removes the “Node.js 20 is deprecated” workflow warnings.

## Test plan
- [x] Confirm CI workflows start without Node.js 20 deprecation annotations
- [x] Confirm pre-commit and tests still pass


Made with [Cursor](https://cursor.com)