### PR TITLE
[#89602] Fix hr_attendance AccessError on read for RO users

### DIFF
--- a/hr_attendance_read_access/README.rst
+++ b/hr_attendance_read_access/README.rst
@@ -1,0 +1,46 @@
+Overview
+========
+
+Allow users who only have read access to attendances to open the
+*Attendances* list and form views without getting an access error.
+
+Problem
+=======
+
+``hr.attendance`` stores several computed fields (``worked_hours``,
+``overtime_hours``, ``validated_overtime_hours``, ``expected_hours`` and
+``overtime_status``). When a dependency changes - for example when overtime
+rules or working schedules are updated - the affected attendance records are
+flagged for recomputation.
+
+The next time those records are read, the ORM recomputes the values and flushes
+them to the database. Because that flush is a ``write`` on ``hr.attendance``, a
+user granted read-only access hits::
+
+    AccessError: You can only read this record. (hr.attendance - write)
+
+simply by opening *Time Off / Attendances*.
+
+Solution
+========
+
+The module inherits ``hr.attendance`` and extends the common fetch path
+(``_fetch_query``). For users that lack write access, any pending recomputation
+of the stored computed fields is recomputed and flushed with elevated
+privileges *before* the user's read triggers it. The system persists its own
+computed values without granting the reading user any write capability, and
+users who already have write access keep the standard behaviour.
+
+Usage
+=====
+
+Install the module. No configuration is required.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Open Source Integrators <http://www.opensourceintegrators.com>

--- a/hr_attendance_read_access/__init__.py
+++ b/hr_attendance_read_access/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2026 - TODAY, Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/hr_attendance_read_access/__manifest__.py
+++ b/hr_attendance_read_access/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2026 - TODAY, Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "HR Attendance Read Access Fix",
+    "version": "18.0.1.0.0",
+    "license": "AGPL-3",
+    "summary": """
+    Let read-only users open the Attendances list/form without hitting a
+    "hr.attendance - write" access error caused by stored computed fields.
+    """,
+    "author": "Open Source Integrators",
+    "maintainers": ["Open Source Integrators"],
+    "website": "https://github.com/ursais/osi-addons",
+    "category": "Human Resources/Attendances",
+    "depends": ["hr_attendance"],
+    "data": [],
+    "installable": True,
+}

--- a/hr_attendance_read_access/models/__init__.py
+++ b/hr_attendance_read_access/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2026 - TODAY, Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import hr_attendance

--- a/hr_attendance_read_access/models/hr_attendance.py
+++ b/hr_attendance_read_access/models/hr_attendance.py
@@ -1,0 +1,61 @@
+# Copyright (C) 2026 - TODAY, Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
+from odoo import models
+
+_logger = logging.getLogger(__name__)
+
+
+class HrAttendance(models.Model):
+    _inherit = "hr.attendance"
+
+    def _flush_pending_computations_as_superuser(self):
+        """Persist pending recomputations of stored computed fields as superuser.
+
+        ``hr.attendance`` owns several ``store=True`` computed fields
+        (``worked_hours``, ``overtime_hours``, ``validated_overtime_hours``,
+        ``expected_hours``, ``overtime_status``). Whenever a dependency changes
+        - for instance when overtime rules or working schedules are updated -
+        the related attendance records are marked for recomputation.
+
+        The next time those records are read (e.g. when a user simply opens the
+        *Attendances* list or form) the ORM recomputes the values and flushes
+        them back to the database. That flush is a ``write`` on
+        ``hr.attendance``, so a user who was granted read-only access to
+        attendances hits ``AccessError: ... (hr.attendance - write)`` even
+        though they only intended to *view* the records.
+
+        Recomputing and flushing the values with elevated privileges lets the
+        system persist its own computed values without granting the reading
+        user any write capability over the records. Officers and managers, who
+        already have write access, keep the standard behaviour and are not
+        impacted.
+        """
+        # ``sudo()`` recomputations re-enter this hook; the elevated call has
+        # nothing left to defer, so skip it and avoid infinite recursion.
+        if self.env.su:
+            return
+
+        attendance_model = self.env["hr.attendance"]
+
+        # Only users lacking write access are affected by the regression.
+        # Skipping the extra flush for everyone else keeps the read path as
+        # light as possible.
+        if attendance_model.has_access("write"):
+            return
+
+        # ``flush_model`` first recomputes every pending stored field of the
+        # model and then writes the dirty values. Running it as superuser
+        # guarantees the persistence never fails for read-only users while
+        # keeping the exact same values the standard recomputation would store.
+        attendance_model.sudo().flush_model()
+
+    def _fetch_query(self, query, fields):
+        # ``_fetch_query`` is the single method every read path funnels through
+        # (``read``/``web_read`` for the form view and ``search_fetch`` for the
+        # list view), which makes it the right place to neutralise the pending
+        # recomputation before the current user triggers the write.
+        self._flush_pending_computations_as_superuser()
+        return super()._fetch_query(query, fields)


### PR DESCRIPTION
: Fixes regression in `hr_attendance` where `read` method triggers `AccessError` for users with read-only access. The ORM previously attempted to access write-restricted fields (e.g., `employee_id`) during list view loading.